### PR TITLE
feat: replace fixed 2s sleep with deterministic file-tile wait

### DIFF
--- a/src/constants/selectors.ts
+++ b/src/constants/selectors.ts
@@ -31,6 +31,10 @@ export const SELECTORS = {
   /** Plus button that opens the file attachment menu */
   FILE_ADD_BUTTON: '[data-testid="composer-plus-btn"]',
 
+  /** File tile that appears in the composer after a file is attached.
+   *  Uses the Tailwind group name which is specific to file tiles. */
+  FILE_ATTACHMENT_TILE: '.group\\/file-tile',
+
   // ── Messages ─────────────────────────────────────────────
   /** All assistant response messages */
   ASSISTANT_MESSAGE: '[data-message-author-role="assistant"]',

--- a/src/core/chatgpt-driver.ts
+++ b/src/core/chatgpt-driver.ts
@@ -327,9 +327,11 @@ export class ChatGPTDriver {
     const fileInput = this.page.locator(SELECTORS.FILE_INPUT_GENERIC);
     await fileInput.setInputFiles(filePaths);
 
-    // Fixed delay while ChatGPT processes the attachment.
-    // Replace with event-based wait when a suitable selector is identified.
-    await this.page.waitForTimeout(2000);
+    // Wait for all file tiles to appear in the composer.
+    await this.page
+      .locator(SELECTORS.FILE_ATTACHMENT_TILE)
+      .nth(filePaths.length - 1)
+      .waitFor({ state: 'visible', timeout: 10_000 });
     progress('Files attached', quiet);
   }
 


### PR DESCRIPTION
## Summary
- `attachFiles()` の固定2秒スリープを、ファイルタイルDOM出現の決定的な待機に置換
- `.group/file-tile` セレクタで添付完了を検出（ライブテストで49msで検出確認）
- 複数ファイル添付時は `filePaths.length` 番目のタイル出現を待機

## Test plan
- [x] 単一ファイル添付のライブテスト（README.md）
- [x] 複数ファイル添付のライブテスト（README.md + package.json）
- [x] `npm run lint && npm run typecheck && npm test` パス
- [x] Codex review 実施・指摘対応済み

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)