### PR TITLE
feat: add read command to retrieve conversation messages

### DIFF
--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -1,0 +1,56 @@
+import { defineCommand } from 'citty';
+
+import type { ConversationMessage } from '../core/chatgpt-driver.js';
+import { jsonRaw, text, validateFormat } from '../core/output-handler.js';
+import { withDriver } from '../core/with-driver.js';
+
+/**
+ * Format conversation messages as human-readable text.
+ * Each message is prefixed with its role label.
+ */
+function formatAsText(messages: readonly ConversationMessage[]): string {
+  return messages
+    .map((m) => `[${m.role}]\n${m.content}`)
+    .join('\n\n');
+}
+
+/**
+ * `cavendish read <chat-id>` — read messages from an existing conversation.
+ */
+export const readCommand = defineCommand({
+  meta: {
+    name: 'read',
+    description: 'Read messages from an existing ChatGPT conversation',
+  },
+  args: {
+    chatId: {
+      type: 'positional',
+      description: 'The conversation ID to read',
+      required: true,
+    },
+    quiet: {
+      type: 'boolean',
+      description: 'Suppress stderr progress messages',
+    },
+    format: {
+      type: 'string',
+      description: 'Output format: json or text (default: json)',
+      default: 'json',
+    },
+  },
+  async run({ args }): Promise<void> {
+    const quiet = args.quiet === true;
+    const format = validateFormat(args.format);
+    if (format === undefined) {return;}
+
+    await withDriver(quiet, async (driver) => {
+      const messages = await driver.readConversation(args.chatId, quiet);
+
+      if (format === 'text') {
+        text(formatAsText(messages));
+      } else {
+        jsonRaw(messages);
+      }
+    });
+  },
+});

--- a/src/core/chatgpt-driver.ts
+++ b/src/core/chatgpt-driver.ts
@@ -20,6 +20,11 @@ export interface ProjectItem {
   href: string;
 }
 
+export interface ConversationMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
 const THINKING_EFFORT_LEVELS: readonly ThinkingEffortLevel[] = [
   'light', 'standard', 'extended', 'deep',
 ] as const;
@@ -375,6 +380,67 @@ export class ChatGPTDriver {
       const last = messages[messages.length - 1];
       return last.textContent.trim();
     }, SELECTORS.ASSISTANT_MESSAGE);
+  }
+
+  // ── Reading ───────────────────────────────────────────────
+
+  /**
+   * Read all messages from a conversation.
+   *
+   * Navigates to the chat and extracts user/assistant messages in DOM order.
+   * Consecutive assistant messages (e.g. thinking steps from reasoning models)
+   * are grouped into a single turn; only the last message in each group is kept.
+   */
+  async readConversation(chatId: string, quiet = false): Promise<ConversationMessage[]> {
+    await this.navigateToChat(chatId, quiet);
+
+    // Wait for at least one message to render after navigation.
+    const messageSelector = `${SELECTORS.USER_MESSAGE}, ${SELECTORS.ASSISTANT_MESSAGE}`;
+    await this.page.locator(messageSelector).first().waitFor({
+      state: 'visible',
+      timeout: 10_000,
+    });
+
+    progress('Reading conversation messages...', quiet);
+
+    const rawMessages = await this.page.evaluate(
+      ({ userSel, assistantSel }: { userSel: string; assistantSel: string }) => {
+        const allElements = document.querySelectorAll(
+          `${userSel}, ${assistantSel}`,
+        );
+        const result: { role: 'user' | 'assistant'; content: string }[] = [];
+        for (const el of allElements) {
+          const role = el.getAttribute('data-message-author-role') as
+            | 'user'
+            | 'assistant';
+          result.push({ role, content: (el.textContent || '').trim() });
+        }
+        return result;
+      },
+      {
+        userSel: SELECTORS.USER_MESSAGE,
+        assistantSel: SELECTORS.ASSISTANT_MESSAGE,
+      },
+    );
+
+    // Collapse consecutive assistant messages into one turn (keep last).
+    // Thinking models emit multiple assistant nodes per turn.
+    const messages: ConversationMessage[] = [];
+    for (const msg of rawMessages) {
+      if (
+        msg.role === 'assistant' &&
+        messages.length > 0 &&
+        messages[messages.length - 1].role === 'assistant'
+      ) {
+        // Replace previous assistant message with this one (keep last in group)
+        messages[messages.length - 1] = msg;
+      } else {
+        messages.push(msg);
+      }
+    }
+
+    progress(`Read ${String(messages.length)} message(s)`, quiet);
+    return messages;
   }
 
   // ── Private ────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { askCommand } from './commands/ask.js';
 import { deleteCommand } from './commands/delete.js';
 import { listCommand } from './commands/list.js';
 import { projectsCommand } from './commands/projects.js';
+import { readCommand } from './commands/read.js';
 
 const main = defineCommand({
   meta: {
@@ -19,6 +20,7 @@ const main = defineCommand({
     delete: deleteCommand,
     list: listCommand,
     projects: projectsCommand,
+    read: readCommand,
   },
 });
 


### PR DESCRIPTION
## Summary
- 新コマンド `cavendish read <chat-id>` を追加
- 既存チャットのメッセージ履歴（user/assistant）をDOM順で取得
- thinkingモデルの中間ステップ（連続するassistantメッセージ）は最終回答のみ保持
- `--format json`（デフォルト）と `--format text` をサポート

## Usage
```bash
cavendish read <chat-id> --format json   # JSON配列出力
cavendish read <chat-id> --format text   # 会話形式テキスト出力
```

## Test plan
- [x] JSON形式のライブテスト（4メッセージ正常取得）
- [x] テキスト形式のライブテスト（会話内容を正確に表示）
- [x] thinkingステップの折りたたみ確認（各ターン最終回答のみ）
- [x] `npm run lint && npm run typecheck && npm test` パス
- [x] Codex review 実施・指摘確認済み

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* 既存のチャットGPT会話からメッセージを読み込む新しいコマンドを追加しました。JSON形式またはテキスト形式での出力に対応し、静かモードで進捗表示を抑制できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->