### PR TITLE
fix: replace launchPersistentContext with detached spawn + CDP connect

### DIFF
--- a/src/core/browser-manager.ts
+++ b/src/core/browser-manager.ts
@@ -85,21 +85,23 @@ export class BrowserManager {
       detached: true,
       stdio: 'ignore',
     });
+    child.unref();
 
-    // Capture spawn errors (e.g. Chrome not found, permission denied) so they
-    // surface as an actionable message instead of an unhandled exception.
-    const spawnError = new Promise<Error>((_, reject) => {
-      child.on('error', (err: Error) => {
+    // Wait for the process to actually start before polling CDP.
+    // 'spawn' fires once the OS has successfully created the process;
+    // 'error' fires if the binary is missing, not executable, etc.
+    await new Promise<void>((resolve, reject) => {
+      child.once('spawn', () => {
+        resolve();
+      });
+      child.once('error', (err: Error) => {
         reject(
           new Error(`Failed to launch Chrome at "${chromePath}": ${err.message}`),
         );
       });
     });
 
-    child.unref();
-
-    // Race: either CDP becomes available or spawn fails
-    await Promise.race([this.waitForCdp(quiet), spawnError]);
+    await this.waitForCdp(quiet);
     await this.connect(quiet);
     this.saveCdpEndpoint();
     progress('Chrome launched', quiet);


### PR DESCRIPTION
## Summary

- `launchPersistentContext` caused `Browser window not found` on macOS due to `--remote-debugging-pipe` (Playwright internal) conflicting with `--remote-debugging-port`
- `context.close()` killed Chrome on exit, causing `exit_type: Crashed` and losing session cookies every time
- Replaced with `child_process.spawn` (detached) + CDP polling + `connectOverCDP`, matching the approach in `docs/live-test.md`

## Changes

- **`src/core/browser-manager.ts`**: Replace `chromium.launchPersistentContext()` with detached `spawn()` + `waitForCdp()` + `connectOverCDP()`
- Remove `persistentContext` field — all connections are now CDP-based
- Add `findChromePath()` for cross-platform Chrome discovery
- Add `waitForCdp()` with 15s polling timeout
- `close()` only disconnects Playwright, Chrome stays running for future reconnection

## Test plan

- [x] Cold start: Chrome not running → auto-launch → ask succeeds
- [x] Warm reconnect: Chrome already running → CDP reconnect → ask succeeds
- [x] Session persistence: Chrome quit (osascript) → re-launch → login preserved
- [x] Error reproduction: reverted to old code → confirmed `Browser window not found`
- [x] `npm run typecheck && npm run lint && npm test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ブラウザ接続をCDPベースへ移行し、切り離されたChromeプロセスとの接続/再接続を可能にするライフサイクルに変更しました。公開APIの署名と呼び出しは維持されます。
* **Bug Fixes**
  * Chrome起動失敗や接続準備の競合に対する検出・回復処理を強化しました。Chrome探索とCDP準備のリトライ/待機を導入し、信頼性を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->