### PR TITLE
docs: sync README and plan.md with current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,15 +156,22 @@ cavendish projects --name "For-Agents" --chats
 cavendish projects --create --name "New Project"
 ```
 
-### Common Options
+### Global Options (all commands)
+
+```bash
+--quiet                  # Suppress progress output
+--dry-run                # Validate args without executing
+```
+
+### Options for ask / deep-research
 
 ```bash
 --format text|json       # Output format (default: json)
 --stream                 # NDJSON streaming output
 --timeout 120            # Timeout in seconds (default: 120, Pro: 2400, DR: 1800)
---quiet                  # Suppress progress output
---dry-run                # Validate args without executing
 ```
+
+> `--format` is also accepted by `list`, `read`, `projects`, and `status`. `doctor` uses its own `--json` flag.
 
 ## Architecture
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -117,14 +117,23 @@ cavendish ask --project "For-Agents" "プロジェクトの方針を教えてく
 # 既存チャットに追加メッセージ
 cavendish ask --continue "続きを詳しく説明してください"
 
-# ストリーミング出力（NDJSON）
-cavendish ask --stream "質問テキスト"
+# 特定のチャットIDで継続
+cavendish ask --continue --chat <chat-id> "続きの質問"
+
+# Google Driveファイル添付
+cavendish ask --gdrive "document.pdf" "このファイルを分析して"
+
+# GitHubリポジトリ連携
+cavendish ask --github "owner/repo" "このコードベースをレビューして"
 
 # エージェントモード
 cavendish ask --agent "問題を解いてください"
 
-# 特定のチャットIDで継続
-cavendish ask --continue --chat <chat-id> "続きの質問"
+# Thinking effort設定（Thinking/Proモデル向け）
+cavendish ask --model thinking --thinking-effort extended "難しい問題"
+
+# ストリーミング出力（NDJSON）
+cavendish ask --stream "質問テキスト"
 
 # ドライラン（実行せず引数検証のみ）
 cavendish ask --dry-run "質問テキスト"
@@ -136,14 +145,21 @@ cavendish ask --dry-run "質問テキスト"
 # Deep Researchクエリ
 cavendish deep-research "調査テーマ"
 
+# ファイル添付
+cavendish deep-research --file ./data.csv "このデータを分析して"
+
 # フォローアップチャット
 cavendish deep-research --chat <chat-id> "追加の質問"
 
-# Google Driveファイル添付
-cavendish deep-research --gdrive "document.pdf" "このファイルを分析して"
+# 同一プロンプトで再実行
+cavendish deep-research --chat <chat-id> --refresh
 
-# GitHubリポジトリ連携
-cavendish deep-research --github "owner/repo" "このリポジトリをレビューして"
+# レポートをエクスポート（markdown / word / pdf）
+cavendish deep-research --export markdown "調査テーマ"
+cavendish deep-research --export pdf --exportPath ./report.pdf "調査テーマ"
+
+# ストリーミング出力
+cavendish deep-research --stream "調査テーマ"
 ```
 
 ### 4.4 チャット管理系
@@ -178,16 +194,25 @@ cavendish projects
 cavendish projects --name "For-Agents" --chats
 ```
 
-### 4.6 出力オプション（全コマンド共通）
+### 4.6 共通オプション
+
+#### 全コマンド共通
+
+```bash
+--quiet           # 進捗表示なし
+--dry-run         # 実行せず引数検証のみ
+```
+
+#### ask / deep-research 共通
 
 ```bash
 --format text     # プレーンテキスト
 --format json     # 構造化出力（デフォルト、メタデータ含む）
 --stream          # NDJSONストリーミング出力
---timeout 120     # 秒数指定（デフォルト: 120秒）
---quiet           # 進捗表示なし
---dry-run         # 実行せず引数検証のみ
+--timeout 120     # 秒数指定（デフォルト: 120秒、Pro: 2400秒、DR: 1800秒）
 ```
+
+※ `--format` は `list`, `read`, `projects`, `status` でも利用可能。`doctor` は独自の `--json` フラグを使用。
 
 ---
 


### PR DESCRIPTION
## Summary

- README: add init/doctor/deep-research commands, streaming/agent flags, update architecture diagram, project structure, and dev commands
- plan.md: rename chatgpt-cli to cavendish throughout, add Phase 4/5 features, update module design with errors/doctor/NDJSON, update selector summary (70+ in 14 categories), add structured error table

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 初期化フローを改善（cavendish initでブラウザ新プロファイル起動、ログインがCLI間で保持）
  * Ask/Deep Research機能拡張（ローカル添付、Google Drive/GitHub連携、エージェントモード、継続チャットID指定）
  * 出力フォーマット強化（json既定、NDJSONストリーミング、構造化エラーのstderr出力）
  * コマンド拡張（--stream/--dry-run/--format/--model/--timeout 等）

* **ドキュメント**
  * READMEと操作ガイド大幅更新、Init/Diagnosticsと検証手順追加
  * プロジェクト名を「Cavendish」へ統一

* **ツール/診断**
  * status/doctor（--json含む）でマシン可読な診断を提供
<!-- end of auto-generated comment: release notes by coderabbit.ai -->