### PR TITLE
fix: use failValidation for format-aware validation errors (#77)

### DIFF
--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from 'citty';
 
 import { FORMAT_ARG, GLOBAL_ARGS } from '../core/cli-args.js';
-import { fail, outputList, progress, validateFormat } from '../core/output-handler.js';
+import { failValidation, outputList, progress, validateFormat } from '../core/output-handler.js';
 import { withDriver } from '../core/with-driver.js';
 
 /**
@@ -37,12 +37,12 @@ export const projectsCommand = defineCommand({
     const createProject = args.create === true;
 
     if (showChats && projectName === undefined) {
-      fail('--chats requires --name. Use: cavendish projects --name "Project" --chats');
+      failValidation('--chats requires --name. Use: cavendish projects --name "Project" --chats', format);
       return;
     }
 
     if (createProject && projectName === undefined) {
-      fail('--create requires --name. Use: cavendish projects --create --name "Project"');
+      failValidation('--create requires --name. Use: cavendish projects --create --name "Project"', format);
       return;
     }
 

--- a/src/commands/read.ts
+++ b/src/commands/read.ts
@@ -3,7 +3,7 @@ import { defineCommand } from 'citty';
 import { assertValidChatId } from '../constants/selectors.js';
 import type { ConversationMessage } from '../core/chatgpt-driver.js';
 import { FORMAT_ARG, GLOBAL_ARGS } from '../core/cli-args.js';
-import { fail, jsonRaw, progress, text, validateFormat } from '../core/output-handler.js';
+import { errorMessage, failValidation, jsonRaw, progress, text, validateFormat } from '../core/output-handler.js';
 import { withDriver } from '../core/with-driver.js';
 
 /** Structured output for the read command in JSON mode. */
@@ -49,7 +49,7 @@ export const readCommand = defineCommand({
     try {
       assertValidChatId(args.chatId);
     } catch (error: unknown) {
-      fail(error instanceof Error ? error.message : String(error));
+      failValidation(errorMessage(error), format);
       return;
     }
 

--- a/tests/output-handler.test.ts
+++ b/tests/output-handler.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { CavendishError, EXIT_CODES } from '../src/core/errors.js';
-import { emitChunk, emitFinal, emitState, failStructured, json, ndjsonChunk, progress, text } from '../src/core/output-handler.js';
+import { emitChunk, emitFinal, emitState, fail, failStructured, failValidation, json, ndjsonChunk, progress, text, validateFormat } from '../src/core/output-handler.js';
 
 describe('OutputHandler', () => {
   const writeCalls: string[] = [];
@@ -301,5 +301,95 @@ describe('OutputHandler', () => {
       expect(writeCalls).toHaveLength(0);
       expect(errorCalls.length).toBeGreaterThan(0);
     });
+  });
+
+  describe('failValidation()', () => {
+    afterEach(() => {
+      process.exitCode = undefined;
+    });
+
+    it('writes structured JSON error to stderr when format is json', () => {
+      failValidation('--timeout must be a positive number', 'json');
+
+      expect(errorCalls).toHaveLength(1);
+      const parsed: unknown = JSON.parse(errorCalls[0] ?? '');
+      expect(parsed).toMatchObject({
+        error: true,
+        category: 'unknown',
+        message: '--timeout must be a positive number',
+        exitCode: EXIT_CODES.unknown,
+      });
+      expect(parsed).toHaveProperty('action');
+    });
+
+    it('writes plain-text error to stderr when format is text', () => {
+      failValidation('--chats requires --name', 'text');
+
+      expect(errorCalls).toHaveLength(1);
+      expect(errorCalls[0]).toContain('--chats requires --name');
+      expect(() => JSON.parse(errorCalls[0] ?? '') as unknown).toThrow();
+    });
+
+    it('defaults to text output when format is omitted', () => {
+      failValidation('some validation error');
+
+      expect(errorCalls).toHaveLength(1);
+      expect(errorCalls[0]).toContain('some validation error');
+      expect(() => JSON.parse(errorCalls[0] ?? '') as unknown).toThrow();
+    });
+
+    it('sets exit code to 1 (unknown category)', () => {
+      failValidation('bad arg', 'json');
+      expect(process.exitCode).toBe(EXIT_CODES.unknown);
+    });
+
+    it('does not write to stdout', () => {
+      failValidation('error msg', 'json');
+
+      expect(writeCalls).toHaveLength(0);
+      expect(errorCalls.length).toBeGreaterThan(0);
+    });
+
+  });
+
+  describe('validateFormat()', () => {
+    afterEach(() => {
+      process.exitCode = undefined;
+    });
+
+    it('returns "json" for valid json input', () => {
+      expect(validateFormat('json')).toBe('json');
+    });
+
+    it('returns "text" for valid text input', () => {
+      expect(validateFormat('text')).toBe('text');
+    });
+
+    it('returns undefined and sets exitCode for invalid format', () => {
+      const result = validateFormat('xml');
+
+      expect(result).toBeUndefined();
+      expect(process.exitCode).toBe(1);
+      expect(errorCalls.some((c) => c.includes('--format must be'))).toBe(true);
+    });
+  });
+
+  describe('fail()', () => {
+    afterEach(() => {
+      process.exitCode = undefined;
+    });
+
+    it('writes plain-text error to stderr', () => {
+      fail('something went wrong');
+
+      expect(errorCalls).toHaveLength(1);
+      expect(errorCalls[0]).toContain('something went wrong');
+    });
+
+    it('sets exit code to 1', () => {
+      fail('error');
+      expect(process.exitCode).toBe(1);
+    });
+
   });
 });


### PR DESCRIPTION
## Summary
- `read.ts`: `fail()` → `failValidation(errorMessage(error), format)` でchatId検証エラーをformat-awareに
- `projects.ts`: 2箇所の `fail()` → `failValidation(..., format)` で `--chats`/`--create` 検証エラーをformat-awareに
- `failValidation()`, `validateFormat()`, `fail()` のユニットテスト10件追加

### 変更しなかったもの（意図的）
- `delete.ts`, `move.ts`, `archive.ts` — `--format` 未サポートのため `fail()` が正しい
- `validateFormat()` — format自体が不正な場合はJSON出力を決定できないため `fail()` が正しい
- `ask.ts` — 既に `failValidation()` 対応済み

## Test plan
- [x] `npm run lint` — pass
- [x] `npm run typecheck` — pass
- [x] `npm test` — 96 tests pass (新規10件含む)

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタ**
  * エラーハンドリングの一貫性を改善しました。エラー報告がフォーマット対応の検証メカニズムを使用するようになり、より構造化されたエラー情報を提供します。

* **テスト**
  * エラー処理機能に対する包括的なテストカバレッジを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->