### PR TITLE
fix: unify error handling across all commands (#84)

### DIFF
--- a/src/commands/archive.ts
+++ b/src/commands/archive.ts
@@ -2,7 +2,7 @@ import { defineCommand } from 'citty';
 
 import { assertValidChatId } from '../constants/selectors.js';
 import { GLOBAL_ARGS } from '../core/cli-args.js';
-import { fail, progress } from '../core/output-handler.js';
+import { errorMessage, fail, progress } from '../core/output-handler.js';
 import { withDriver } from '../core/with-driver.js';
 
 /**
@@ -27,7 +27,7 @@ export const archiveCommand = defineCommand({
     try {
       assertValidChatId(args.chatId);
     } catch (error: unknown) {
-      fail(error instanceof Error ? error.message : String(error));
+      fail(errorMessage(error));
       return;
     }
 

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -2,7 +2,7 @@ import { defineCommand } from 'citty';
 
 import { assertValidChatId } from '../constants/selectors.js';
 import { GLOBAL_ARGS } from '../core/cli-args.js';
-import { fail, progress } from '../core/output-handler.js';
+import { errorMessage, fail, progress } from '../core/output-handler.js';
 import { withDriver } from '../core/with-driver.js';
 
 /**
@@ -33,7 +33,7 @@ export const deleteCommand = defineCommand({
     try {
       assertValidChatId(args.chatId);
     } catch (error: unknown) {
-      fail(error instanceof Error ? error.message : String(error));
+      fail(errorMessage(error));
       return;
     }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,7 +6,7 @@ import { type Page, errors } from 'playwright';
 import { CHATGPT_BASE_URL, SELECTORS } from '../constants/selectors.js';
 import { BrowserManager, CDP_BASE_URL, CHROME_PROFILE_DIR } from '../core/browser-manager.js';
 import { FORMAT_ARG, GLOBAL_ARGS } from '../core/cli-args.js';
-import { errorMessage, fail, jsonRaw, progress, text, validateFormat } from '../core/output-handler.js';
+import { errorMessage, failStructured, jsonRaw, progress, text, validateFormat } from '../core/output-handler.js';
 
 /** Polling interval (ms) while waiting for user to log in. */
 const LOGIN_POLL_INTERVAL_MS = 3_000;
@@ -333,7 +333,7 @@ export const initCommand = defineCommand({
         process.exitCode = 1;
       }
     } catch (error: unknown) {
-      fail(`Chrome setup failed: ${errorMessage(error)}. Ensure Chrome is installed and port 9222 is free.`);
+      failStructured(error, format);
     }
   },
 });

--- a/src/commands/move.ts
+++ b/src/commands/move.ts
@@ -2,7 +2,7 @@ import { defineCommand } from 'citty';
 
 import { assertValidChatId } from '../constants/selectors.js';
 import { GLOBAL_ARGS } from '../core/cli-args.js';
-import { fail, progress } from '../core/output-handler.js';
+import { errorMessage, fail, progress } from '../core/output-handler.js';
 import { withDriver } from '../core/with-driver.js';
 
 /**
@@ -32,7 +32,7 @@ export const moveCommand = defineCommand({
     try {
       assertValidChatId(args.chatId);
     } catch (error: unknown) {
-      fail(error instanceof Error ? error.message : String(error));
+      fail(errorMessage(error));
       return;
     }
 


### PR DESCRIPTION
## Summary
- `delete.ts`, `move.ts`, `archive.ts`: `error instanceof Error ? error.message : String(error)` → `errorMessage(error)` に統一
- `init.ts`: `fail()` → `failStructured(error, format)` で `--format json` 時に構造化JSON出力対応

### 変更不要だったコマンド（既に対応済み）
- `ask.ts`, `deep-research.ts`: Phase 6 PR #82 で対応済み
- `read.ts`, `projects.ts`: Phase 6 PR #92 で対応済み
- `list.ts`, `status.ts`: `withDriver()` + `failStructured()` で既に統一済み

## Test plan
- [x] `npm run lint` — pass
- [x] `npm run typecheck` — pass
- [x] `npm test` — 107 tests pass

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * エラーメッセージの処理を統一しました。複数のコマンドにおいて、エラー処理の方式を標準化し、より一貫性のある形式でエラーを表示するように改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->