### PR TITLE
feat: allow stdin-only prompt and add help usage examples (#85)

### DIFF
--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -42,6 +42,9 @@ export function buildPrompt(prompt: string, stdinData: string): string {
   if (stdinData.length === 0) {
     return prompt;
   }
+  if (prompt.length === 0) {
+    return stdinData;
+  }
   return `${stdinData}\n\n${prompt}`;
 }
 
@@ -216,7 +219,11 @@ function validateArgs(args: Record<string, unknown>): ValidatedArgs | undefined 
   } catch (error: unknown) {
     failValidation(errorMessage(error), format); return;
   }
-  const prompt = buildPrompt(args.prompt as string, stdinData);
+  const rawPrompt = (args.prompt as string | undefined) ?? '';
+  if (rawPrompt.length === 0 && stdinData.length === 0) {
+    failValidation('Prompt is required. Provide as argument or pipe via stdin.', format); return;
+  }
+  const prompt = buildPrompt(rawPrompt, stdinData);
   const stream = args.stream === true;
 
   return {
@@ -320,13 +327,21 @@ async function navigate(
 export const askCommand = defineCommand({
   meta: {
     name: 'ask',
-    description: 'Send a prompt to ChatGPT and return the response',
+    description:
+      'Send a prompt to ChatGPT and return the response.\n\n'
+      + 'Usage:\n'
+      + '  cavendish ask "Explain closures in JS"\n'
+      + '  echo "hello" | cavendish ask "Summarize this"\n'
+      + '  cat file.ts | cavendish ask "Review this code"\n'
+      + '  cavendish ask "Fix the bug" --model Thinking --file src/app.ts\n'
+      + '  cavendish ask "Continue" --continue\n'
+      + '  cavendish ask "Follow up" --chat <id>',
   },
   args: {
     prompt: {
       type: 'positional',
-      description: 'The prompt to send to ChatGPT',
-      required: true,
+      description: 'The prompt to send to ChatGPT (can also be provided via stdin pipe)',
+      required: false,
     },
     timeout: {
       type: 'string',

--- a/src/commands/deep-research.ts
+++ b/src/commands/deep-research.ts
@@ -257,7 +257,14 @@ function resolveChatId(driver: ChatGPTDriver, mode: RunMode, quiet: boolean): st
 export const deepResearchCommand = defineCommand({
   meta: {
     name: 'deep-research',
-    description: 'Send a prompt to ChatGPT Deep Research and return the report',
+    description:
+      'Send a prompt to ChatGPT Deep Research and return the report.\n\n'
+      + 'Usage:\n'
+      + '  cavendish deep-research "Compare React vs Vue in 2025"\n'
+      + '  echo "topic" | cavendish deep-research "Analyze this"\n'
+      + '  cavendish deep-research "Follow up" --chat <id>\n'
+      + '  cavendish deep-research --chat <id> --refresh\n'
+      + '  cavendish deep-research "Query" --export markdown --exportPath report.md',
   },
   args: {
     prompt: {

--- a/tests/ask-stdin.test.ts
+++ b/tests/ask-stdin.test.ts
@@ -19,4 +19,12 @@ describe('buildPrompt()', () => {
       'line1\nline2\nline3\n\nsummarize',
     );
   });
+
+  it('returns stdinData alone when prompt is empty (stdin-only pipe)', () => {
+    expect(buildPrompt('', 'piped input')).toBe('piped input');
+  });
+
+  it('returns empty string when both prompt and stdinData are empty', () => {
+    expect(buildPrompt('', '')).toBe('');
+  });
 });


### PR DESCRIPTION
## Summary
- `ask` の positional prompt を `required: false` に変更 — `echo "hello" | cavendish ask` が動作するように
- prompt も stdin もない場合の validation エラーを追加
- `buildPrompt`: stdin のみの場合に正しく stdinData を返すよう修正
- `ask` と `deep-research` の `--help` にUsage例を追加
- 2件のユニットテスト追加（stdin-only、空入力）

## Test plan
- [x] `npm run lint` — pass
- [x] `npm run typecheck` — pass
- [x] `npm test` — 109 tests pass (新規2件含む)

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * askコマンドの引数をオプション化し、標準入力からのプロンプト入力に対応しました。
  * 空のプロンプトの処理をより堅牢に改善しました。

* **ドキュメント**
  * askおよびdeep-researchコマンドの説明を拡張し、使用例を追加しました。

* **テスト**
  * buildPrompt関数の標準入力処理に関するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->