### PR TITLE
fix: add prepublishOnly script to prevent stale dist publishes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run lint && npm run typecheck && npm test && npm run build"
   },
   "keywords": [
     "chatgpt",


### PR DESCRIPTION
## Summary
- `package.json` に `prepublishOnly` スクリプトを追加
- `npm publish` 実行時に lint → typecheck → test → build を自動実行し、古い `dist/` のままパブリッシュすることを防止

Closes #99

## Test plan
- [x] `npm run lint` — pass
- [x] `npm run typecheck` — pass
- [x] `npm test` — 117 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * パッケージ公開前に自動品質チェックが追加されました。リリース前にlintチェック、型チェック、テスト、ビルドが自動実行されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->