### PR TITLE
docs: clarify 0o700 permission scope as POSIX-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Chrome's remote debugging port (9222) is explicitly bound to **127.0.0.1 only** 
 
 ### Chrome Profile Directory
 
-The Chrome profile (`~/.cavendish/chrome-profile`) contains your ChatGPT session cookies. It is created and maintained with **0o700 permissions** (owner-only read/write/execute), so other users on the same machine cannot read it.
+The Chrome profile (`~/.cavendish/chrome-profile`) contains your ChatGPT session cookies. It is created and maintained with **0o700 permissions** (owner-only read/write/execute) on macOS and Linux, so other users on the same machine cannot read it. On Windows, `chmod` only affects the read-only flag, so the directory inherits NTFS ACLs from the user's home directory instead.
 
 ### Clipboard Permissions
 
@@ -284,7 +284,8 @@ Cavendish grants `clipboard-read` and `clipboard-write` permissions to `chatgpt.
 
 If you run Cavendish on a shared machine:
 
-- Verify that `~/.cavendish/` has `drwx------` permissions (`ls -ld ~/.cavendish`).
+- **macOS/Linux**: Verify that `~/.cavendish/` has `drwx------` permissions (`ls -ld ~/.cavendish`).
+- **Windows**: Verify that `%USERPROFILE%\.cavendish\` inherits appropriate NTFS ACLs restricting access to your user account.
 - Ensure no other local user/process can access port 9222. Binding to `127.0.0.1` prevents remote access, but it does not isolate the CDP endpoint from other users on the same machine.
 - Do **not** share your `~/.cavendish/chrome-profile` directory — it contains active session data.
 


### PR DESCRIPTION
## Summary
- Security セクションの Chrome Profile Directory 説明で、`0o700` パーミッションが macOS/Linux のみ有効であることを明記
- Windows では NTFS ACL がユーザーのホームディレクトリから継承される旨を追記
- Multi-user 環境向けガイダンスをプラットフォーム別に分離

Closes #101

## Test plan
- [x] `npm run lint` — pass
- [x] `npm run typecheck` — pass
- [x] `npm test` — 117 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * Chrome プロファイルディレクトリの設定に関するプラットフォーム固有の詳細（macOS/Linux と Windows）を README に追加。
  * 共有マシン環境でのセットアップガイダンスとセキュリティ注意事項を更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->