### PR TITLE
fix: eliminate version duplication via build-time injection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,10 +12,12 @@ import { projectsCommand } from './commands/projects.js';
 import { readCommand } from './commands/read.js';
 import { statusCommand } from './commands/status.js';
 
+declare const __VERSION__: string;
+
 const main = defineCommand({
   meta: {
     name: 'cavendish',
-    version: '0.1.0',
+    version: __VERSION__,
     description:
       'Playwright-based CLI that automates ChatGPT Web UI for coding agents',
   },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from 'tsup';
 
+import pkg from './package.json';
+
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
@@ -9,5 +11,8 @@ export default defineConfig({
   target: 'node20',
   banner: {
     js: '#!/usr/bin/env node',
+  },
+  define: {
+    __VERSION__: JSON.stringify(pkg.version),
   },
 });


### PR DESCRIPTION
## Summary
- `tsup.config.ts` を作成し、`define: { __VERSION__: JSON.stringify(pkg.version) }` でビルド時にバージョンを注入
- `src/index.ts` のハードコード `version: '0.1.0'` を `version: __VERSION__` に置換
- `package.json` の一箇所のみでバージョン管理し、リリース時のズレを防止

Closes #104

## Test plan
- [x] `npm run build` — `dist/index.mjs` に `"0.1.0"` が含まれ、`__VERSION__` リテラルが残っていないことを確認
- [x] `npm run lint` — pass
- [x] `npm run typecheck` — pass
- [x] `npm test` — 117 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

**チョア**
- ビルド時にパッケージのバージョンを自動注入するようになりました。
- アプリ内で表示されるバージョン表記を固定値から注入されたビルド版に切替え、バージョン管理が一貫化されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->