### PR TITLE
test: add DOM-independent unit tests for model-config and chat-id

### DIFF
--- a/tests/chat-id.test.ts
+++ b/tests/chat-id.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertValidChatId,
+  conversationLinkById,
+  conversationLinkByIdBroad,
+  projectConversationLinkById,
+} from '../src/constants/selectors.js';
+
+describe('assertValidChatId()', () => {
+  describe('valid IDs', () => {
+    it('accepts a UUID-style ID', () => {
+      expect(() => { assertValidChatId('6820abc1-def2-3456-7890-abcdef123456'); }).not.toThrow();
+    });
+
+    it('accepts alphanumeric with hyphens', () => {
+      expect(() => { assertValidChatId('abc-123-def'); }).not.toThrow();
+    });
+
+    it('accepts alphanumeric with underscores', () => {
+      expect(() => { assertValidChatId('chat_id_123'); }).not.toThrow();
+    });
+
+    it('accepts purely numeric ID', () => {
+      expect(() => { assertValidChatId('12345'); }).not.toThrow();
+    });
+
+    it('accepts purely alphabetic ID', () => {
+      expect(() => { assertValidChatId('abcdef'); }).not.toThrow();
+    });
+
+    it('accepts mixed alphanumeric with hyphens and underscores', () => {
+      expect(() => { assertValidChatId('a1-b2_c3'); }).not.toThrow();
+    });
+  });
+
+  describe('invalid IDs', () => {
+    it('rejects empty string', () => {
+      expect(() => { assertValidChatId(''); }).toThrow('Invalid conversation ID format');
+    });
+
+    it('rejects CSS selector injection with brackets', () => {
+      expect(() => { assertValidChatId('abc"][onclick="alert(1)'); }).toThrow('Invalid conversation ID format');
+    });
+
+    it('rejects IDs with spaces', () => {
+      expect(() => { assertValidChatId('abc 123'); }).toThrow('Invalid conversation ID format');
+    });
+
+    it('rejects IDs with slashes (path traversal)', () => {
+      expect(() => { assertValidChatId('../etc/passwd'); }).toThrow('Invalid conversation ID format');
+    });
+
+    it('rejects IDs with angle brackets (HTML injection)', () => {
+      expect(() => { assertValidChatId('<script>'); }).toThrow('Invalid conversation ID format');
+    });
+
+    it('rejects IDs with semicolons', () => {
+      expect(() => { assertValidChatId('abc;def'); }).toThrow('Invalid conversation ID format');
+    });
+
+    it('rejects IDs with quotes', () => {
+      expect(() => { assertValidChatId('abc"def'); }).toThrow('Invalid conversation ID format');
+      expect(() => { assertValidChatId("abc'def"); }).toThrow('Invalid conversation ID format');
+    });
+
+    it('rejects IDs with hash symbols', () => {
+      expect(() => { assertValidChatId('#history'); }).toThrow('Invalid conversation ID format');
+    });
+
+    it('includes the invalid ID in the error message', () => {
+      expect(() => { assertValidChatId('bad/id'); }).toThrow('bad/id');
+    });
+  });
+});
+
+describe('conversationLinkById()', () => {
+  it('builds an exact sidebar link selector', () => {
+    const selector = conversationLinkById('abc-123');
+    expect(selector).toBe('#history a[href="/c/abc-123"]');
+  });
+
+  it('throws for invalid IDs', () => {
+    expect(() => { conversationLinkById('bad/id'); }).toThrow('Invalid conversation ID format');
+  });
+});
+
+describe('conversationLinkByIdBroad()', () => {
+  it('builds an ends-with sidebar link selector', () => {
+    const selector = conversationLinkByIdBroad('abc-123');
+    expect(selector).toBe('#history a[href$="/c/abc-123"]');
+  });
+
+  it('throws for invalid IDs', () => {
+    expect(() => { conversationLinkByIdBroad('<script>'); }).toThrow('Invalid conversation ID format');
+  });
+});
+
+describe('projectConversationLinkById()', () => {
+  it('builds a main content area link selector', () => {
+    const selector = projectConversationLinkById('abc-123');
+    expect(selector).toBe('main a[href$="/c/abc-123"]');
+  });
+
+  it('throws for invalid IDs', () => {
+    expect(() => { projectConversationLinkById('"; DROP TABLE'); }).toThrow('Invalid conversation ID format');
+  });
+});

--- a/tests/model-config.test.ts
+++ b/tests/model-config.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  allowedThinkingEfforts,
+  EFFORT_LABEL_CANDIDATES,
+  MODEL_EFFORT_LEVELS,
+  resolveModelCategory,
+  supportsGitHub,
+  THINKING_EFFORT_LEVELS,
+} from '../src/core/model-config.js';
+
+describe('resolveModelCategory()', () => {
+  describe('thinking models', () => {
+    it('returns "thinking" for exact "Thinking"', () => {
+      expect(resolveModelCategory('Thinking')).toBe('thinking');
+    });
+
+    it('is case-insensitive', () => {
+      expect(resolveModelCategory('THINKING')).toBe('thinking');
+      expect(resolveModelCategory('thinking')).toBe('thinking');
+    });
+
+    it('matches when "thinking" appears as substring', () => {
+      expect(resolveModelCategory('o3-mini-thinking')).toBe('thinking');
+      expect(resolveModelCategory('GPT-4-Thinking-Preview')).toBe('thinking');
+    });
+  });
+
+  describe('pro models', () => {
+    it('returns "pro" for exact "Pro"', () => {
+      expect(resolveModelCategory('Pro')).toBe('pro');
+    });
+
+    it('is case-insensitive', () => {
+      expect(resolveModelCategory('PRO')).toBe('pro');
+      expect(resolveModelCategory('pro')).toBe('pro');
+    });
+
+    it('matches when "pro" appears as substring', () => {
+      expect(resolveModelCategory('ChatGPT-Pro')).toBe('pro');
+      expect(resolveModelCategory('gpt-4o-pro-mode')).toBe('pro');
+    });
+  });
+
+  describe('regular models (no thinking effort support)', () => {
+    it('returns undefined for "4o"', () => {
+      expect(resolveModelCategory('4o')).toBeUndefined();
+    });
+
+    it('returns undefined for "gpt-4o"', () => {
+      expect(resolveModelCategory('gpt-4o')).toBeUndefined();
+    });
+
+    it('returns undefined for "4o-mini"', () => {
+      expect(resolveModelCategory('4o-mini')).toBeUndefined();
+    });
+
+    it('returns undefined for empty string', () => {
+      expect(resolveModelCategory('')).toBeUndefined();
+    });
+  });
+
+  describe('priority: "thinking" is checked before "pro"', () => {
+    it('returns "thinking" when model contains both "thinking" and "pro"', () => {
+      expect(resolveModelCategory('pro-thinking-v2')).toBe('thinking');
+    });
+  });
+});
+
+describe('allowedThinkingEfforts()', () => {
+  it('returns all effort levels for thinking models', () => {
+    const efforts = allowedThinkingEfforts('Thinking');
+    expect(efforts).toEqual(THINKING_EFFORT_LEVELS);
+    expect(efforts).toEqual(['light', 'standard', 'extended', 'deep']);
+  });
+
+  it('returns restricted levels for pro models', () => {
+    const efforts = allowedThinkingEfforts('Pro');
+    expect(efforts).toEqual(MODEL_EFFORT_LEVELS.pro);
+    expect(efforts).toEqual(['standard', 'extended']);
+  });
+
+  it('returns undefined for regular models', () => {
+    expect(allowedThinkingEfforts('4o')).toBeUndefined();
+    expect(allowedThinkingEfforts('gpt-4o-mini')).toBeUndefined();
+  });
+
+  it('returns undefined for empty model string', () => {
+    expect(allowedThinkingEfforts('')).toBeUndefined();
+  });
+
+  it('is case-insensitive', () => {
+    expect(allowedThinkingEfforts('THINKING')).toEqual(THINKING_EFFORT_LEVELS);
+    expect(allowedThinkingEfforts('PRO')).toEqual(MODEL_EFFORT_LEVELS.pro);
+  });
+});
+
+describe('supportsGitHub()', () => {
+  it('returns true for thinking models', () => {
+    expect(supportsGitHub('Thinking')).toBe(true);
+  });
+
+  it('returns true for thinking models (case-insensitive)', () => {
+    expect(supportsGitHub('THINKING')).toBe(true);
+    expect(supportsGitHub('thinking')).toBe(true);
+  });
+
+  it('returns false for pro models', () => {
+    expect(supportsGitHub('Pro')).toBe(false);
+  });
+
+  it('returns false for regular models', () => {
+    expect(supportsGitHub('4o')).toBe(false);
+    expect(supportsGitHub('gpt-4o-mini')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(supportsGitHub('')).toBe(false);
+  });
+});
+
+describe('constants', () => {
+  it('THINKING_EFFORT_LEVELS has exactly 4 levels', () => {
+    expect(THINKING_EFFORT_LEVELS).toHaveLength(4);
+  });
+
+  it('EFFORT_LABEL_CANDIDATES covers all effort levels', () => {
+    for (const level of THINKING_EFFORT_LEVELS) {
+      expect(EFFORT_LABEL_CANDIDATES[level]).toBeDefined();
+      expect(EFFORT_LABEL_CANDIDATES[level].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('EFFORT_LABEL_CANDIDATES includes both Japanese and English labels', () => {
+    // Each level should have at least 2 candidates (JP + EN)
+    for (const level of THINKING_EFFORT_LEVELS) {
+      expect(EFFORT_LABEL_CANDIDATES[level].length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it('MODEL_EFFORT_LEVELS.thinking includes all levels', () => {
+    expect(MODEL_EFFORT_LEVELS.thinking).toEqual(THINKING_EFFORT_LEVELS);
+  });
+
+  it('MODEL_EFFORT_LEVELS.pro is a subset of thinking levels', () => {
+    for (const level of MODEL_EFFORT_LEVELS.pro) {
+      expect(THINKING_EFFORT_LEVELS).toContain(level);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `tests/model-config.test.ts`: `resolveModelCategory()`, `allowedThinkingEfforts()`, `supportsGitHub()` の分類ロジックと定数整合性テスト (26 tests)
- `tests/chat-id.test.ts`: `assertValidChatId()` と selector 生成関数のバリデーション。CSS injection、パストラバーサル、HTML injection 等のセキュリティエッジケースを含む (21 tests)

Closes #100

## Test plan
- [x] `npm run lint` — pass
- [x] `npm run typecheck` — pass
- [x] `npm test` — 164 tests pass (10 files, +47 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * チャット ID バリデーションとセレクタービルダーの包括的なテストスイートを追加しました。複数の形式検証とエラーハンドリングをカバーしています。
  * モデル設定ユーティリティの包括的なテストスイートを追加しました。モデルカテゴリ検出と機能サポート検証をカバーしています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->