### PR TITLE
fix: handle zero-byte Blob rejection in clipboard restore

### DIFF
--- a/src/core/driver/deep-research.ts
+++ b/src/core/driver/deep-research.ts
@@ -256,8 +256,13 @@ export async function copyDeepResearchContent(page: Page): Promise<string> {
     // between snapshot and restore is negligible; unconditional restore is acceptable.
     if (clipboardSnapshot !== null) {
       await page.evaluate(async (snapshot: Record<string, string>[]) => {
-        if (snapshot.length === 0) {
-          // Original clipboard was empty — clear to restore that state.
+        // No items or all items have only empty representations → write empty text.
+        // Chrome rejects ClipboardItem with zero-byte Blobs ("Empty dictionary argument"),
+        // so we fall back to writeText('') for clipboards that had no meaningful content.
+        const hasContent = snapshot.some((reps) =>
+          Object.values(reps).some((b64) => b64.length > 0),
+        );
+        if (snapshot.length === 0 || !hasContent) {
           await navigator.clipboard.writeText('');
           return;
         }


### PR DESCRIPTION
## Summary
- Chrome rejects `ClipboardItem` construction with zero-byte Blobs (`"Empty dictionary argument"`)
- This occurs when the user's clipboard contained empty text — `clipboard.read()` returns 1 item with an empty `text/plain` Blob, which fails on restore
- Falls back to `writeText('')` when all snapshot representations are empty

## Found during
Live testing of #113 fix — clipboard preservation test with empty clipboard state.

## Test plan
- [x] Live test: text clipboard preserved and restored after DR copy
- [x] Live test: empty clipboard preserved (was failing, now passes)
- [x] Live test: snapshot failure aborts without destroying clipboard
- [x] `npm run lint && npm run typecheck && npm test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* ディープリサーチ機能のクリップボード内容復元の信頼性が向上しました。空のコンテンツは確実にクリアされ、意味のあるデータは復元時に適切に保持されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->