### PR TITLE
fix: wait for SPA hydration before model picker selection

### DIFF
--- a/src/core/browser-manager.ts
+++ b/src/core/browser-manager.ts
@@ -109,10 +109,9 @@ export class BrowserManager {
     // Wait for SPA hydration: ChatGPT fetches the model list and user
     // preferences via HTTP after DOM is ready.  Without this wait,
     // downstream code (model picker, sidebar) can see stale cached
-    // state.  networkidle fires once HTTP activity settles (WebSocket
-    // connections are excluded).  The timeout is a safety net — if a
-    // long-lived HTTP connection prevents networkidle we proceed and
-    // let callers handle any remaining staleness.
+    // state.  networkidle fires once there are no HTTP connections for
+    // 500 ms.  Persistent connections (WebSockets, SSE) can prevent it
+    // from firing — the 15 s timeout is the safety net for those cases.
     verbose('Waiting for SPA initialization...', isVerbose);
     await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch((e: unknown) => {
       if (e instanceof errors.TimeoutError) {

--- a/src/core/chatgpt-driver.ts
+++ b/src/core/chatgpt-driver.ts
@@ -712,11 +712,12 @@ export class ChatGPTDriver {
 
   /**
    * Wait for model picker menu items to stabilize after SPA hydration.
-   * Polls both data-testid and textContent until two consecutive reads
-   * produce the same snapshot, indicating React has finished updating.
+   * Polls both data-testid and textContent until three consecutive reads
+   * (two consecutive matches) produce the same snapshot, indicating React
+   * has finished updating.
    *
    * @returns `populated` — at least one menu item was found.
-   *          `stabilized` — two consecutive snapshots matched within the timeout.
+   *          `stabilized` — consecutive snapshots matched within the timeout.
    */
   private async waitForModelMenuStable(
     menuItems: Locator,
@@ -729,7 +730,9 @@ export class ChatGPTDriver {
         ).join('|'),
       );
 
+    const REQUIRED_MATCHES = 2;
     let previousSnapshot = await snapshot();
+    let matchCount = 0;
     const deadline = Date.now() + maxWaitMs;
 
     while (Date.now() < deadline) {
@@ -737,7 +740,12 @@ export class ChatGPTDriver {
       const currentSnapshot = await snapshot();
 
       if (currentSnapshot === previousSnapshot && currentSnapshot.length > 0) {
-        return { populated: true, stabilized: true };
+        matchCount += 1;
+        if (matchCount >= REQUIRED_MATCHES) {
+          return { populated: true, stabilized: true };
+        }
+      } else {
+        matchCount = 0;
       }
 
       previousSnapshot = currentSnapshot;


### PR DESCRIPTION
## Summary

- **networkidle wait in `getPage()`**: After `domcontentloaded`, wait for HTTP activity to settle (max 15s timeout) so the SPA has fetched the model list and user preferences before downstream code interacts with the page
- **Stability poll in `selectModel()`**: After opening the model picker menu, poll `data-testid` + `textContent` snapshots until two consecutive reads match — secondary safety net against mid-render menu updates
- Only timeout errors are swallowed; other errors (page close, navigation failure) are rethrown

Closes #118

## Test plan

- [x] Live Chrome test: 15+ sequential runs — all selected `model-switcher-gpt-5-4-pro`
- [x] Live Chrome test: 3 batches × 3 parallel tabs — all selected latest model
- [x] Full send flow probe: verified model at every stage (page load → new chat → select → fill → submit → response)
- [x] `npm run lint && npm run typecheck && npm test` — all pass (175 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正・改善**
  * チャット画面読み込み時にSPAの初期化完了を待つよう強化し、モデル一覧やユーザー設定が確実に反映されるようになりました。これにより表示の不整合や古い状態の発生が減ります。
  * モデル選択の安定性を向上させ、メニューの変化を検出して正しい項目を選択するようにしました。タイムアウト時の安全なフォールバックも追加しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->