### PR TITLE
fix: moveToProject exact match, readConversation message loss, projects flag conflict

### DIFF
--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -4,6 +4,23 @@ import { FORMAT_ARG, GLOBAL_ARGS } from '../core/cli-args.js';
 import { failValidation, outputList, progress, validateFormat } from '../core/output-handler.js';
 import { withDriver } from '../core/with-driver.js';
 
+export function validateProjectArgs(
+  showChats: boolean,
+  createProject: boolean,
+  projectName: string | undefined,
+): string | null {
+  if (showChats && createProject) {
+    return '--chats and --create are mutually exclusive. Use one at a time.';
+  }
+  if (showChats && projectName === undefined) {
+    return '--chats requires --name. Use: cavendish projects --name "Project" --chats';
+  }
+  if (createProject && projectName === undefined) {
+    return '--create requires --name. Use: cavendish projects --create --name "Project"';
+  }
+  return null;
+}
+
 /**
  * `cavendish projects` — list projects, project chats, or create a project.
  */
@@ -37,13 +54,9 @@ export const projectsCommand = defineCommand({
     const showChats = args.chats === true;
     const createProject = args.create === true;
 
-    if (showChats && projectName === undefined) {
-      failValidation('--chats requires --name. Use: cavendish projects --name "Project" --chats', format);
-      return;
-    }
-
-    if (createProject && projectName === undefined) {
-      failValidation('--create requires --name. Use: cavendish projects --create --name "Project"', format);
+    const validationError = validateProjectArgs(showChats, createProject, projectName);
+    if (validationError !== null) {
+      failValidation(validationError, format);
       return;
     }
 

--- a/src/core/chatgpt-driver.ts
+++ b/src/core/chatgpt-driver.ts
@@ -339,24 +339,21 @@ export class ChatGPTDriver {
       throw error;
     }
 
-    const count = await projectItem.count();
-    if (count > 1) {
-      for (let i = 0; i < count; i++) {
-        const text = await projectItem.nth(i).textContent();
-        if (text?.trim() === projectName) {
-          await projectItem.nth(i).click();
-          progress(`Conversation moved to project: ${projectName}`, quiet);
-          return;
-        }
-      }
-      await this.page.keyboard.press('Escape');
-      throw new Error(
-        `Multiple projects partially match "${projectName}" but none is an exact match. Please use the full project name.`,
-      );
+    const texts: (string | null)[] = await projectItem.evaluateAll(
+      (els) => els.map((el) => el.textContent),
+    );
+    const matchIndex = texts.findIndex((t) => t?.trim() === projectName);
+    if (matchIndex !== -1) {
+      await projectItem.nth(matchIndex).click();
+      progress(`Conversation moved to project: ${projectName}`, quiet);
+      return;
     }
-    await projectItem.first().click();
-
-    progress(`Conversation moved to project: ${projectName}`, quiet);
+    await this.page.keyboard.press('Escape');
+    throw new Error(
+      texts.length > 1
+        ? `Multiple projects partially match "${projectName}" but none is an exact match. Please use the full project name.`
+        : `Project "${projectName}" partially matched but is not an exact match (found: "${texts[0]?.trim() ?? ''}"). Please use the full project name.`,
+    );
   }
 
   // ── Composer + menu (submenu navigation) ───────────────────
@@ -584,21 +581,8 @@ export class ChatGPTDriver {
       },
     );
 
-    const messages: ConversationMessage[] = [];
-    for (const msg of rawMessages) {
-      if (
-        msg.role === 'assistant' &&
-        messages.length > 0 &&
-        messages[messages.length - 1].role === 'assistant'
-      ) {
-        messages[messages.length - 1] = msg;
-      } else {
-        messages.push(msg);
-      }
-    }
-
-    progress(`Read ${String(messages.length)} message(s)`, quiet);
-    return messages;
+    progress(`Read ${String(rawMessages.length)} message(s)`, quiet);
+    return rawMessages;
   }
 
   // ── Private ────────────────────────────────────────────────

--- a/tests/projects-validation.test.ts
+++ b/tests/projects-validation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateProjectArgs } from '../src/commands/projects.js';
+
+describe('validateProjectArgs', () => {
+  it('returns null when no flags are set', () => {
+    expect(validateProjectArgs(false, false, undefined)).toBeNull();
+  });
+
+  it('returns null for --chats with --name', () => {
+    expect(validateProjectArgs(true, false, 'MyProject')).toBeNull();
+  });
+
+  it('returns null for --create with --name', () => {
+    expect(validateProjectArgs(false, true, 'MyProject')).toBeNull();
+  });
+
+  it('rejects --chats and --create together', () => {
+    const result = validateProjectArgs(true, true, 'MyProject');
+    expect(result).toMatch(/mutually exclusive/);
+  });
+
+  it('rejects --chats without --name', () => {
+    const result = validateProjectArgs(true, false, undefined);
+    expect(result).toMatch(/--chats requires --name/);
+  });
+
+  it('rejects --create without --name', () => {
+    const result = validateProjectArgs(false, true, undefined);
+    expect(result).toMatch(/--create requires --name/);
+  });
+
+  it('prioritizes mutual exclusion over missing --name', () => {
+    const result = validateProjectArgs(true, true, undefined);
+    expect(result).toMatch(/mutually exclusive/);
+  });
+});


### PR DESCRIPTION
## Summary

- **#124** `moveToProject()`: Always validate exact match via `evaluateAll` before clicking. Previously, when only one project partially matched, it was clicked without verifying exact match — potentially moving conversations to the wrong project.
- **#125** `readConversation()`: Remove dedup logic that dropped consecutive assistant messages. The previous code replaced earlier assistant messages with later ones when they appeared consecutively, causing data loss.
- **#127** `projects --create --chats`: Reject mutually exclusive flags with a clear error message instead of silently prioritizing one.

Closes #124, #125, #127

## Test plan

- [x] Live Chrome test: `projects --create --chats --name "X"` returns mutual exclusion error
- [x] Live Chrome test: `read <DR-chat-id>` preserves 4 consecutive assistant messages
- [x] Live Chrome test: `move <id> --project "For-Agents"` succeeds with exact match
- [x] Live Chrome test: `ask "verified"` returns expected response (regression)
- [x] Unit test: `validateProjectArgs` — 7 test cases covering all validation paths
- [x] `npm run lint && npm run typecheck && npm test` — 13 files, 182 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プロジェクト選択の精度が向上しました。完全一致するプロジェクト名を正確に識別できるようになりました。
  * コマンドライン引数の検証が改善されました。互いに排他的なフラグの組み合わせが適切に検出されるようになりました。
  * 会話メッセージの処理が更新されました。

* **テスト**
  * プロジェクト引数検証のテストスイートが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->