### PR TITLE
fix(cli): support --format on delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ cavendish status --json       # JSON output (same as doctor --json)
 
 | Flag | Scope | Description |
 |------|-------|-------------|
-| `--format text\|json` | ask, deep-research, list, read, projects | Output format (default: `json`) |
+| `--format text\|json` | ask, deep-research, delete, list, read, projects | Output / error format (default: `json`) |
 | `--stream` | ask, deep-research | NDJSON streaming output |
 | `--detach` | ask, deep-research | Submit a background job and return immediately |
 | `--notify-file <path>` | ask, deep-research | Append a completion notification JSON line to a local file |

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,8 +1,8 @@
 import { defineCommand } from 'citty';
 
 import { assertValidChatId } from '../constants/selectors.js';
-import { GLOBAL_ARGS, rejectUnknownFlags } from '../core/cli-args.js';
-import { errorMessage, fail, progress } from '../core/output-handler.js';
+import { FORMAT_ARG, GLOBAL_ARGS, rejectUnknownFlags } from '../core/cli-args.js';
+import { errorMessage, failValidation, progress, validateFormat } from '../core/output-handler.js';
 import { withDriver } from '../core/with-driver.js';
 
 /**
@@ -20,6 +20,7 @@ const DELETE_ARGS = {
     description: 'Project name (required for project conversations)',
   },
   ...GLOBAL_ARGS,
+  ...FORMAT_ARG,
 };
 
 export const deleteCommand = defineCommand({
@@ -29,16 +30,18 @@ export const deleteCommand = defineCommand({
   },
   args: DELETE_ARGS,
   async run({ args }): Promise<void> {
-    if (!rejectUnknownFlags(DELETE_ARGS)) { return; }
-
     const quiet = args.quiet === true;
     const isVerbose = args.verbose === true;
     const projectName = args.project;
+    const format = validateFormat(args.format);
+    if (format === undefined) { return; }
+
+    if (!rejectUnknownFlags(DELETE_ARGS, format)) { return; }
 
     try {
       assertValidChatId(args.chatId);
     } catch (error: unknown) {
-      fail(errorMessage(error));
+      failValidation(errorMessage(error), format);
       return;
     }
 
@@ -57,6 +60,6 @@ export const deleteCommand = defineCommand({
       } else {
         await driver.deleteConversation(args.chatId, quiet);
       }
-    }, undefined, { verbose: isVerbose });
+    }, format, { verbose: isVerbose });
   },
 });

--- a/src/core/cli-args.ts
+++ b/src/core/cli-args.ts
@@ -23,13 +23,13 @@ export const GLOBAL_ARGS = {
 };
 
 /**
- * Format arg for commands that produce structured output.
- * Commands like archive/delete/move that have no formatted output should not include this.
+ * Format arg for commands that support text/json stdout or JSON-formatted errors.
+ * Commands like archive/move that never vary their output or error shape should not include this.
  */
 export const FORMAT_ARG = {
   format: {
     type: 'string' as const,
-    description: 'Output format: json or text (default: json)',
+    description: 'Output / error format: json or text (default: json)',
     default: 'json',
   },
 };

--- a/tests/delete-command.test.ts
+++ b/tests/delete-command.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { deleteCommand } from '../src/commands/delete.js';
+
+describe('deleteCommand', () => {
+  it('accepts --format json without treating it as an unknown option', async () => {
+    const run = deleteCommand.run;
+    if (run === undefined) {
+      throw new Error('deleteCommand.run is undefined');
+    }
+
+    const chatId = '12345678-1234-1234-1234-123456789012';
+    const origArgv = process.argv;
+    const origExitCode = process.exitCode;
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const args = {
+      _: [],
+      chatId,
+      dryRun: true,
+      format: 'json',
+      project: undefined,
+      quiet: false,
+      verbose: false,
+    } as unknown as Parameters<NonNullable<typeof deleteCommand.run>>[0]['args'];
+
+    try {
+      process.argv = ['node', 'index.mjs', 'delete', chatId, '--format', 'json', '--dry-run'];
+      process.exitCode = undefined;
+
+      await run({
+        args,
+        rawArgs: [],
+        cmd: deleteCommand,
+      });
+
+      expect(process.exitCode).toBeUndefined();
+      const stderrOutput = stderrSpy.mock.calls.flat().join('');
+      expect(stderrOutput).not.toContain('Unknown option');
+    } finally {
+      process.argv = origArgv;
+      process.exitCode = origExitCode;
+      stderrSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- allow `cavendish delete` to accept `--format` and route validation/runtime errors through the selected format
- align README/help text with the actual `delete --format` behavior
- add a regression test covering `delete --format json --dry-run`

## Testing
- npm test -- tests/delete-command.test.ts tests/unknown-flags.test.ts
- npm run typecheck
- npm run lint

Closes #160


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * deleteコマンドで`--format`フラグをサポート。出力形式をJSONまたはテキストで指定可能に。

* **ドキュメント**
  * README と CLI引数ドキュメントを更新し、deleteコマンドのフォーマット対応を反映。

* **テスト**
  * deleteコマンドのフォーマット引数検証をカバーするテストスイートを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->