### PR TITLE
chore(release): bump version to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavendish",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavendish",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "citty": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavendish",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Playwright-based CLI tool that automates ChatGPT's Web UI, enabling coding agents to query ChatGPT Pro models via a single shell command",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary
- bump `cavendish` package version from `1.0.1` to `1.0.2`
- align the root `package-lock.json` version fields with the package version

## Notes
- release bump only
- current `main` already includes the jobs JSON output fix merged in PR #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノーツ

* **Chores**
  * パッケージバージョンを1.0.2にアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->