### PR TITLE
fix(jobs): pass detached job prompt via argv instead of stdinData

### DIFF
--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -314,6 +314,9 @@ function buildAskJobArgv(validated: ValidatedArgs): string[] {
   if (validated.thinkingEffort !== undefined) {
     argv.push('--thinking-effort', validated.thinkingEffort);
   }
+  // End-of-options separator so prompts starting with '--' are not
+  // misinterpreted as flags when the worker re-invokes the CLI.
+  argv.push('--', validated.prompt);
   return argv;
 }
 
@@ -354,7 +357,6 @@ function submitDetachedAskJob(validated: ValidatedArgs): DetachedSubmitPayload {
   const record = submitDetachedJob({
     kind: 'ask',
     argv: buildAskJobArgv(validated),
-    stdinData: validated.prompt,
     notifyFile: validated.notifyFile,
   });
   return {

--- a/src/commands/deep-research.ts
+++ b/src/commands/deep-research.ts
@@ -233,7 +233,7 @@ function validateArgs(args: Record<string, unknown>): ValidatedArgs | undefined 
 }
 
 function buildDeepResearchJobArgv(v: ValidatedArgs): string[] {
-  const argv = ['deep-research', '--timeout', String(v.timeoutSec)];
+  const argv = ['deep-research'];
   if (v.mode.kind === 'refresh') {
     argv.push('--chat', v.mode.chatId, '--refresh');
   } else if (v.mode.kind === 'followup') {
@@ -243,11 +243,17 @@ function buildDeepResearchJobArgv(v: ValidatedArgs): string[] {
       argv.push('--file', filePath);
     }
   }
+  argv.push('--timeout', String(v.timeoutSec));
   if (v.exportFormat !== undefined) {
     argv.push('--export', v.exportFormat);
   }
   if (v.exportPath !== undefined) {
     argv.push('--exportPath', v.exportPath);
+  }
+  // End-of-options separator so prompts starting with '--' are not
+  // misinterpreted as flags when the worker re-invokes the CLI.
+  if (v.mode.kind !== 'refresh') {
+    argv.push('--', v.mode.prompt);
   }
   return argv;
 }
@@ -256,7 +262,6 @@ function submitDetachedDeepResearchJob(v: ValidatedArgs): DetachedSubmitPayload 
   const record = submitDetachedJob({
     kind: 'deep-research',
     argv: buildDeepResearchJobArgv(v),
-    stdinData: v.mode.kind === 'refresh' ? undefined : v.mode.prompt,
     notifyFile: v.notifyFile,
   });
   return {

--- a/src/core/jobs/worker.ts
+++ b/src/core/jobs/worker.ts
@@ -63,7 +63,16 @@ function parseStructuredError(line: string): StructuredErrorPayload | undefined 
 }
 
 function buildWorkerArgs(job: JobRecord): string[] {
-  return [...job.argv, '--stream', '--format', 'json', '--quiet'];
+  const workerFlags = ['--stream', '--format', 'json', '--quiet'];
+  const dashDashIdx = job.argv.indexOf('--');
+  if (dashDashIdx === -1) {
+    return [...job.argv, ...workerFlags];
+  }
+  // Insert worker flags before the '--' separator so they are not
+  // treated as positional arguments by the child's arg parser.
+  const before = job.argv.slice(0, dashDashIdx);
+  const fromDash = job.argv.slice(dashDashIdx);
+  return [...before, ...workerFlags, ...fromDash];
 }
 
 function finalizeJobStatus(event: NdjsonEvent): Extract<JobStatus, 'completed' | 'timed_out'> {

--- a/tests/ask-detach.test.ts
+++ b/tests/ask-detach.test.ts
@@ -9,6 +9,8 @@ const SAFE_EVENTS_PATH = join(process.cwd(), '.tmp-tests', 'events.ndjson');
 let jsonRawMock: ReturnType<typeof vi.fn>;
 let failValidationMock: ReturnType<typeof vi.fn>;
 let submitDetachedJobMock: ReturnType<typeof vi.fn>;
+let readStdinMock: ReturnType<typeof vi.fn>;
+let buildPromptMock: ReturnType<typeof vi.fn>;
 
 vi.mock('../src/core/browser-manager.js', () => ({
   BrowserManager: vi.fn(() => ({
@@ -22,16 +24,20 @@ vi.mock('../src/core/chatgpt-driver.js', () => ({
   ChatGPTDriver: vi.fn(() => ({})),
 }));
 
-vi.mock('../src/core/cli-args.js', () => ({
-  FORMAT_ARG: {},
-  GLOBAL_ARGS: {},
-  STREAM_ARG: {},
-  buildPrompt: vi.fn((prompt: string): string => prompt),
-  extractArgsOrFail: vi.fn((flag: string) => (flag === 'gdrive' ? ['drive-doc'] : [])),
-  readStdin: vi.fn().mockReturnValue(''),
-  rejectUnknownFlags: vi.fn().mockReturnValue(true),
-  validateFileArgs: vi.fn().mockReturnValue([SAFE_CONTEXT_PATH]),
-}));
+vi.mock('../src/core/cli-args.js', () => {
+  readStdinMock = vi.fn().mockReturnValue('');
+  buildPromptMock = vi.fn((prompt: string): string => prompt);
+  return {
+    FORMAT_ARG: {},
+    GLOBAL_ARGS: {},
+    STREAM_ARG: {},
+    buildPrompt: buildPromptMock,
+    extractArgsOrFail: vi.fn((flag: string) => (flag === 'gdrive' ? ['drive-doc'] : [])),
+    readStdin: readStdinMock,
+    rejectUnknownFlags: vi.fn().mockReturnValue(true),
+    validateFileArgs: vi.fn().mockReturnValue([SAFE_CONTEXT_PATH]),
+  };
+});
 
 vi.mock('../src/core/model-config.js', () => ({
   allowedThinkingEfforts: vi.fn().mockReturnValue(['light', 'standard', 'extended', 'deep']),
@@ -144,10 +150,10 @@ describe('ask --detach', () => {
       '--agent',
       '--thinking-effort',
       'standard',
+      '--',
+      'hello',
     ]);
-    expect(submitDetachedJobMock).toHaveBeenCalledWith(expect.objectContaining({
-      stdinData: 'hello',
-    }));
+    expect(request.stdinData).toBeUndefined();
 
     const payload = jsonRawMock.mock.calls[0]?.[0] as DetachedSubmitPayload | undefined;
     expect(payload).toBeDefined();
@@ -161,6 +167,48 @@ describe('ask --detach', () => {
     expect(payload.jobPath).toBe(SAFE_JOB_PATH);
     expect(payload.eventsPath).toBe(SAFE_EVENTS_PATH);
     expect(payload.notifyFile).toMatch(/notify\.ndjson$/);
+  });
+
+  it('includes stdin-only prompt in argv instead of stdinData (#175)', async () => {
+    // Simulate stdin-only: readStdin returns the prompt, buildPrompt returns it
+    readStdinMock.mockReturnValueOnce('stdin-only prompt');
+    buildPromptMock.mockReturnValueOnce('stdin-only prompt');
+
+    const { askCommand } = await import('../src/commands/ask.js');
+    const run = askCommand.run;
+    if (run === undefined) {
+      throw new Error('askCommand.run is undefined');
+    }
+
+    await run({
+      args: {
+        _: [],
+        prompt: undefined,
+        model: 'Pro',
+        quiet: false,
+        verbose: false,
+        stream: false,
+        dryRun: false,
+        format: 'json',
+        continue: false,
+        agent: false,
+        detach: true,
+      } as never,
+      rawArgs: [],
+      cmd: askCommand,
+    });
+
+    expect(submitDetachedJobMock).toHaveBeenCalledOnce();
+    const request = submitDetachedJobMock.mock.calls[0]?.[0] as DetachedJobRequest | undefined;
+    expect(request).toBeDefined();
+    if (request === undefined) {
+      throw new Error('Detached ask request was not captured');
+    }
+    // The prompt must be a positional arg in argv (after '--'), not in stdinData
+    expect(request.argv[0]).toBe('ask');
+    expect(request.argv.at(-2)).toBe('--');
+    expect(request.argv.at(-1)).toBe('stdin-only prompt');
+    expect(request.stdinData).toBeUndefined();
   });
 
   it('rejects --stream together with --detach', async () => {

--- a/tests/deep-research-detach.test.ts
+++ b/tests/deep-research-detach.test.ts
@@ -124,15 +124,18 @@ describe('deep-research --detach', () => {
     expect(request.notifyFile).toMatch(/dr-notify\.ndjson$/);
     expect(request.argv).toEqual([
       'deep-research',
-      '--timeout',
-      '1800',
       '--file',
       SAFE_RESEARCH_PATH,
+      '--timeout',
+      '1800',
       '--export',
       'markdown',
       '--exportPath',
       './report.md',
+      '--',
+      'research topic',
     ]);
+    expect(request).not.toHaveProperty('stdinData');
 
     const payload = jsonRawMock.mock.calls[0]?.[0] as SubmitPayload | undefined;
     expect(payload).toBeDefined();

--- a/tests/jobs-worker.test.ts
+++ b/tests/jobs-worker.test.ts
@@ -40,6 +40,7 @@ async function importWithMocks(
 ): Promise<{
   store: typeof import('../src/core/jobs/store.js');
   worker: typeof import('../src/core/jobs/worker.js');
+  spawnMock: ReturnType<typeof vi.fn>;
 }> {
   vi.resetModules();
   vi.doMock('node:os', async () => {
@@ -49,12 +50,13 @@ async function importWithMocks(
       homedir: (): string => testRoot,
     };
   });
+  const spawnMock = vi.fn(() => spawnImpl());
   vi.doMock('node:child_process', () => ({
-    spawn: vi.fn(() => spawnImpl()),
+    spawn: spawnMock,
   }));
   const store = await import('../src/core/jobs/store.js');
   const worker = await import('../src/core/jobs/worker.js');
-  return { store, worker };
+  return { store, worker, spawnMock };
 }
 
 describe('job worker', () => {
@@ -245,5 +247,35 @@ describe('job worker', () => {
       worker.markUnexpectedJobFailure(job.jobId, new Error('boom'));
     }).not.toThrow();
     expect(store.readJobError(job.jobId)?.message).toBe('boom');
+  });
+
+  it('places worker flags before the -- separator in argv (#175)', async () => {
+    const finalLine = JSON.stringify({
+      type: 'final',
+      content: 'done',
+      timestamp: '2026-03-14T00:00:00.000Z',
+      partial: false,
+    });
+    const { store, worker, spawnMock } = await importWithMocks(() => makeChild([finalLine], [], 0));
+    const job = store.createJob({
+      kind: 'ask',
+      argv: ['ask', '--model', 'Pro', '--timeout', '120', '--', 'my prompt'],
+    });
+
+    await worker.runJobWorker(job.jobId);
+
+    const spawnArgs = spawnMock.mock.calls[0]?.[1] as string[] | undefined;
+    expect(spawnArgs).toBeDefined();
+    if (spawnArgs === undefined) {
+      throw new Error('spawn was not called');
+    }
+    // Worker flags (--stream, --format, --quiet) must appear before '--'
+    const dashDashIdx = spawnArgs.indexOf('--');
+    expect(dashDashIdx).toBeGreaterThan(-1);
+    expect(spawnArgs.indexOf('--stream')).toBeLessThan(dashDashIdx);
+    expect(spawnArgs.indexOf('--format')).toBeLessThan(dashDashIdx);
+    expect(spawnArgs.indexOf('--quiet')).toBeLessThan(dashDashIdx);
+    // Prompt must appear after '--'
+    expect(spawnArgs[dashDashIdx + 1]).toBe('my prompt');
   });
 });


### PR DESCRIPTION
## Summary

- Detached stdin-only `ask` jobs could time out without emitting any `chunk`/`final` events because the prompt was piped to the child process via `stdinData`, which was unreliable on some platforms
- Move the prompt into `argv` as a positional argument after a `--` end-of-options separator so it is never misinterpreted as a CLI flag
- Update `buildWorkerArgs` in `worker.ts` to insert worker flags (`--stream`, `--format`, `--quiet`) before the `--` separator
- Apply the same fix to `deep-research` detached jobs

## Test plan

- [x] Unit tests: 3 new test cases (stdin-only detach, `--` separator handling in worker, deep-research argv)
- [x] All 343 tests pass (`npm run lint && npm run typecheck && npm test`)
- [x] Live Chrome test: `printf '...' | node dist/index.mjs ask --detach` completes with `LIVE-FIX175-STDIN-DETACH` response and proper `chunk` → `final` → `job-completed` event sequence

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * "--" で始まるプロンプトが正しく処理されるようになり、コマンドフラグとして誤解釈されなくなりました
  * ask コマンドおよび deep-research コマンドの引数処理を改善し、デタッチされたジョブ実行時の信頼性が向上しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->