### PR TITLE
fix(response): search copy button at article level (#177)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -66,6 +66,7 @@ Every feature/fix follows this sequence:
    - DOM-dependent code (ChatGPTDriver, BrowserManager): run the **Live Chrome Test** checklist (see Testing section)
    - DOM-independent code (OutputHandler, ConfigManager, utils): write and run vitest unit tests
    - When responding to review comments: verify with live test BEFORE deciding to fix or skip
+   - **After live tests: delete all test conversations** created during verification via `cavendish delete <id>`
    - Mark complete after verification:
    ```bash
    jq '.steps.live_test_done = true' .claude/.workflow-state > tmp && mv tmp .claude/.workflow-state

--- a/src/core/driver/response-handler.ts
+++ b/src/core/driver/response-handler.ts
@@ -183,7 +183,10 @@ async function getResponseSnapshot(
 
       const target = messages[messages.length - 1];
       const text = target.textContent.trim();
-      const copyButton = target.querySelector<HTMLElement>(copySelector);
+      // The copy button lives in the enclosing <article>, not inside the
+      // assistant message element itself (ChatGPT DOM change, Chrome 145+).
+      const article = target.closest('article');
+      const copyButton = (article ?? target).querySelector<HTMLElement>(copySelector);
       const copyButtonVisible = copyButton !== null && copyButton.getBoundingClientRect().height > 0;
 
       return { text, copyButtonVisible };


### PR DESCRIPTION
## Summary

- ChatGPT's DOM now places the copy button (`[data-testid="copy-turn-action-button"]`) as a sibling of `[data-message-author-role="assistant"]` at the `<article>` level, not as a descendant
- `getResponseSnapshot()` searched inside the assistant message element, causing `copyButtonVisible` to always be `false`
- This broke the fast-path completion detection, making `ask` stall on default timeouts (exit code 7)
- Fix: search from `target.closest('article')` instead of `target` directly
- Also adds test chat cleanup step to the Development Cycle in CLAUDE.md

## Test plan

- [x] `npm run lint && npm run typecheck && npm test` — all pass (39 files, 343 tests)
- [x] Live test: `ask "Reply with only: FIX_VERIFIED" --timeout 120` — completes successfully
- [x] Live test: `echo "Reply with only: STDIN_OK" | ask --timeout 120` — completes successfully
- [x] Live test: `doctor` — 7/7 pass
- [x] Codex review — no regressions found

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- ChatGPT環境におけるコピーボタンの検出ロジックを改善いたしました。これにより、ユーザーはより安定した操作体験が得られるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->