### PR TITLE
fix(jobs): pass detached prompt via file instead of argv (#178)

### DIFF
--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -314,9 +314,6 @@ function buildAskJobArgv(validated: ValidatedArgs): string[] {
   if (validated.thinkingEffort !== undefined) {
     argv.push('--thinking-effort', validated.thinkingEffort);
   }
-  // End-of-options separator so prompts starting with '--' are not
-  // misinterpreted as flags when the worker re-invokes the CLI.
-  argv.push('--', validated.prompt);
   return argv;
 }
 
@@ -357,6 +354,7 @@ function submitDetachedAskJob(validated: ValidatedArgs): DetachedSubmitPayload {
   const record = submitDetachedJob({
     kind: 'ask',
     argv: buildAskJobArgv(validated),
+    prompt: validated.prompt,
     notifyFile: validated.notifyFile,
   });
   return {

--- a/src/commands/deep-research.ts
+++ b/src/commands/deep-research.ts
@@ -250,11 +250,6 @@ function buildDeepResearchJobArgv(v: ValidatedArgs): string[] {
   if (v.exportPath !== undefined) {
     argv.push('--exportPath', v.exportPath);
   }
-  // End-of-options separator so prompts starting with '--' are not
-  // misinterpreted as flags when the worker re-invokes the CLI.
-  if (v.mode.kind !== 'refresh') {
-    argv.push('--', v.mode.prompt);
-  }
   return argv;
 }
 
@@ -262,6 +257,7 @@ function submitDetachedDeepResearchJob(v: ValidatedArgs): DetachedSubmitPayload 
   const record = submitDetachedJob({
     kind: 'deep-research',
     argv: buildDeepResearchJobArgv(v),
+    prompt: v.mode.kind !== 'refresh' ? v.mode.prompt : undefined,
     notifyFile: v.notifyFile,
   });
   return {

--- a/src/core/jobs/store.ts
+++ b/src/core/jobs/store.ts
@@ -9,10 +9,12 @@ import type { DetachedJobRequest, JobKind, JobRecord, JobResultRecord, JobStatus
 
 const JOBS_DIR = join(CAVENDISH_DIR, 'jobs');
 const JOB_FILE = 'job.json';
+const PROMPT_FILE = 'prompt.txt';
 const EVENTS_FILE = 'events.ndjson';
 const RESULT_FILE = 'result.json';
 const ERROR_FILE = 'error.json';
 const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const JOB_KINDS: readonly JobKind[] = ['ask', 'deep-research'];
 const JOB_STATUSES: readonly JobStatus[] = ['queued', 'running', 'completed', 'failed', 'timed_out', 'cancelled'];
@@ -61,6 +63,18 @@ export function getJobErrorPath(jobId: string): string {
   return join(getJobDir(jobId), ERROR_FILE);
 }
 
+export function getJobPromptPath(jobId: string): string {
+  return join(getJobDir(jobId), PROMPT_FILE);
+}
+
+export function readJobPrompt(jobId: string): string {
+  const path = getJobPromptPath(jobId);
+  if (!existsSync(path)) {
+    return '';
+  }
+  return readFileSync(path, 'utf8');
+}
+
 export function createJob(request: DetachedJobRequest): JobRecord {
   const jobId = randomUUID();
   const submittedAt = new Date().toISOString();
@@ -69,7 +83,6 @@ export function createJob(request: DetachedJobRequest): JobRecord {
     kind: request.kind,
     status: 'queued',
     argv: request.argv,
-    stdinData: request.stdinData,
     notifyFile: request.notifyFile,
     submittedAt,
     updatedAt: submittedAt,
@@ -78,6 +91,15 @@ export function createJob(request: DetachedJobRequest): JobRecord {
     eventsPath: getJobEventsPath(jobId),
     errorPath: getJobErrorPath(jobId),
   };
+  // Write the prompt file before persisting the job record so that an
+  // already-running detached runner cannot pick up the job before the
+  // prompt is available on disk.
+  if (request.prompt !== undefined && request.prompt.length > 0) {
+    ensureDir(getJobDir(jobId));
+    const promptPath = getJobPromptPath(jobId);
+    writeFileSync(promptPath, request.prompt);
+    chmodSync(promptPath, FILE_MODE);
+  }
   saveJob(record);
   return record;
 }
@@ -165,7 +187,6 @@ function assertValidJobRecordShape(record: unknown, label: string): asserts reco
   if (typeof candidate.retryCount !== 'number' || !Number.isInteger(candidate.retryCount) || candidate.retryCount < 0) {
     throw new Error(`${label} is missing required retryCount metadata. Recreate the detached job and retry.`);
   }
-  assertOptionalStringField(candidate.stdinData, 'stdinData', label);
   assertOptionalStringField(candidate.notifyFile, 'notifyFile', label);
   assertOptionalStringField(candidate.startedAt, 'startedAt', label);
   assertOptionalStringField(candidate.completedAt, 'completedAt', label);

--- a/src/core/jobs/types.ts
+++ b/src/core/jobs/types.ts
@@ -14,7 +14,7 @@ export type JobStatus =
 export interface DetachedJobRequest {
   kind: JobKind;
   argv: string[];
-  stdinData?: string;
+  prompt?: string;
   notifyFile?: string;
 }
 
@@ -23,7 +23,6 @@ export interface JobRecord {
   kind: JobKind;
   status: JobStatus;
   argv: string[];
-  stdinData?: string;
   notifyFile?: string;
   submittedAt: string;
   updatedAt: string;

--- a/src/core/jobs/worker.ts
+++ b/src/core/jobs/worker.ts
@@ -6,7 +6,7 @@ import { progress } from '../output-handler.js';
 import type { NdjsonEvent } from '../output-handler.js';
 
 import { notifyJobCompletion } from './notifier.js';
-import { appendJobEvent, readJob, updateJob, writeJobError, writeJobResult } from './store.js';
+import { appendJobEvent, readJob, readJobPrompt, updateJob, writeJobError, writeJobResult } from './store.js';
 import type { JobRecord, JobStatus } from './types.js';
 
 export type JobRunOutcome = 'completed' | 'failed' | 'timed_out' | 'retry';
@@ -64,12 +64,13 @@ function parseStructuredError(line: string): StructuredErrorPayload | undefined 
 
 function buildWorkerArgs(job: JobRecord): string[] {
   const workerFlags = ['--stream', '--format', 'json', '--quiet'];
+  // Preserve backwards compatibility with jobs queued before the prompt-file
+  // migration: if argv still contains a '--' separator, insert worker flags
+  // before it so they are not treated as positional arguments.
   const dashDashIdx = job.argv.indexOf('--');
   if (dashDashIdx === -1) {
     return [...job.argv, ...workerFlags];
   }
-  // Insert worker flags before the '--' separator so they are not
-  // treated as positional arguments by the child's arg parser.
   const before = job.argv.slice(0, dashDashIdx);
   const fromDash = job.argv.slice(dashDashIdx);
   return [...before, ...workerFlags, ...fromDash];
@@ -100,7 +101,7 @@ async function runWorkerAttempt(jobId: string, job: JobRecord): Promise<{
       CAVENDISH_ALLOW_PARTIAL: '1',
     },
   });
-  child.stdin.end(job.stdinData ?? '');
+  child.stdin.end(readJobPrompt(job.jobId));
 
   let finalEvent: NdjsonEvent | undefined;
   let structuredError: StructuredErrorPayload | undefined;

--- a/tests/ask-detach.test.ts
+++ b/tests/ask-detach.test.ts
@@ -150,10 +150,8 @@ describe('ask --detach', () => {
       '--agent',
       '--thinking-effort',
       'standard',
-      '--',
-      'hello',
     ]);
-    expect(request.stdinData).toBeUndefined();
+    expect(request.prompt).toBe('hello');
 
     const payload = jsonRawMock.mock.calls[0]?.[0] as DetachedSubmitPayload | undefined;
     expect(payload).toBeDefined();
@@ -169,8 +167,7 @@ describe('ask --detach', () => {
     expect(payload.notifyFile).toMatch(/notify\.ndjson$/);
   });
 
-  it('includes stdin-only prompt in argv instead of stdinData (#175)', async () => {
-    // Simulate stdin-only: readStdin returns the prompt, buildPrompt returns it
+  it('passes stdin-only prompt via prompt field, not argv (#178)', async () => {
     readStdinMock.mockReturnValueOnce('stdin-only prompt');
     buildPromptMock.mockReturnValueOnce('stdin-only prompt');
 
@@ -204,11 +201,10 @@ describe('ask --detach', () => {
     if (request === undefined) {
       throw new Error('Detached ask request was not captured');
     }
-    // The prompt must be a positional arg in argv (after '--'), not in stdinData
-    expect(request.argv[0]).toBe('ask');
-    expect(request.argv.at(-2)).toBe('--');
-    expect(request.argv.at(-1)).toBe('stdin-only prompt');
-    expect(request.stdinData).toBeUndefined();
+    // Prompt must be in the prompt field, not in argv (avoids ps exposure)
+    expect(request.prompt).toBe('stdin-only prompt');
+    expect(request.argv).not.toContain('--');
+    expect(request.argv).not.toContain('stdin-only prompt');
   });
 
   it('rejects --stream together with --detach', async () => {

--- a/tests/deep-research-detach.test.ts
+++ b/tests/deep-research-detach.test.ts
@@ -69,6 +69,7 @@ vi.mock('../src/constants/selectors.js', async () => {
 
 interface DetachedRequest {
   kind: string;
+  prompt?: string;
   notifyFile?: string;
   argv: string[];
 }
@@ -132,10 +133,8 @@ describe('deep-research --detach', () => {
       'markdown',
       '--exportPath',
       './report.md',
-      '--',
-      'research topic',
     ]);
-    expect(request).not.toHaveProperty('stdinData');
+    expect(request.prompt).toBe('research topic');
 
     const payload = jsonRawMock.mock.calls[0]?.[0] as SubmitPayload | undefined;
     expect(payload).toBeDefined();

--- a/tests/jobs-worker.test.ts
+++ b/tests/jobs-worker.test.ts
@@ -12,7 +12,7 @@ function makeChild(
   stdoutLines: string[],
   stderrLines: string[],
   exitCode: number,
-): EventEmitter & { stdout: PassThrough; stderr: PassThrough } {
+): EventEmitter & { stdin: PassThrough; stdout: PassThrough; stderr: PassThrough } {
   const child = new EventEmitter() as EventEmitter & {
     stdin: PassThrough;
     stdout: PassThrough;
@@ -249,17 +249,25 @@ describe('job worker', () => {
     expect(store.readJobError(job.jobId)?.message).toBe('boom');
   });
 
-  it('places worker flags before the -- separator in argv (#175)', async () => {
+  it('pipes prompt file content to child stdin instead of argv (#178)', async () => {
     const finalLine = JSON.stringify({
       type: 'final',
       content: 'done',
       timestamp: '2026-03-14T00:00:00.000Z',
       partial: false,
     });
-    const { store, worker, spawnMock } = await importWithMocks(() => makeChild([finalLine], [], 0));
+    let capturedStdinData = '';
+    const { store, worker, spawnMock } = await importWithMocks(() => {
+      const child = makeChild([finalLine], [], 0);
+      child.stdin.on('data', (chunk: Buffer) => {
+        capturedStdinData += chunk.toString();
+      });
+      return child;
+    });
     const job = store.createJob({
       kind: 'ask',
-      argv: ['ask', '--model', 'Pro', '--timeout', '120', '--', 'my prompt'],
+      argv: ['ask', '--model', 'Pro', '--timeout', '120'],
+      prompt: 'my prompt from file',
     });
 
     await worker.runJobWorker(job.jobId);
@@ -269,13 +277,14 @@ describe('job worker', () => {
     if (spawnArgs === undefined) {
       throw new Error('spawn was not called');
     }
-    // Worker flags (--stream, --format, --quiet) must appear before '--'
-    const dashDashIdx = spawnArgs.indexOf('--');
-    expect(dashDashIdx).toBeGreaterThan(-1);
-    expect(spawnArgs.indexOf('--stream')).toBeLessThan(dashDashIdx);
-    expect(spawnArgs.indexOf('--format')).toBeLessThan(dashDashIdx);
-    expect(spawnArgs.indexOf('--quiet')).toBeLessThan(dashDashIdx);
-    // Prompt must appear after '--'
-    expect(spawnArgs[dashDashIdx + 1]).toBe('my prompt');
+    // Prompt must NOT appear in argv (avoids ps exposure and ARG_MAX)
+    expect(spawnArgs).not.toContain('my prompt from file');
+    expect(spawnArgs).not.toContain('--');
+    // Worker flags must be appended
+    expect(spawnArgs).toContain('--stream');
+    expect(spawnArgs).toContain('--format');
+    expect(spawnArgs).toContain('--quiet');
+    // Prompt must be piped via stdin from the prompt file
+    expect(capturedStdinData).toBe('my prompt from file');
   });
 });

--- a/tests/submit-detached-job.test.ts
+++ b/tests/submit-detached-job.test.ts
@@ -59,14 +59,14 @@ describe('submitDetachedJob', () => {
       const record: { jobId: string; kind: string } = submitDetachedJob({
         kind: 'ask',
         argv: ['ask', 'hello'],
-        stdinData: 'hello from stdin',
+        prompt: 'hello from stdin',
         notifyFile: NOTIFY_FILE,
       });
 
       expect(createJobMock).toHaveBeenCalledWith({
         kind: 'ask',
         argv: ['ask', 'hello'],
-        stdinData: 'hello from stdin',
+        prompt: 'hello from stdin',
         notifyFile: NOTIFY_FILE,
       });
       const spawnCall = spawnMock.mock.calls[0] as


### PR DESCRIPTION
## Summary

- Moves detached job prompt from process argv to `~/.cavendish/jobs/<uuid>/prompt.txt` (mode 0o600)
- Prevents prompt content from being visible in `ps` output (security fix)
- Avoids `ARG_MAX` limits for large prompts (~950KB+ would SIGSEGV on macOS)
- Worker reads prompt file and pipes to child stdin
- Preserves backwards compatibility with pre-migration jobs that still have `--` in argv
- Writes prompt file before job.json to avoid race with already-running runner
- Removes dead `stdinData` field from `JobRecord` type

## Test plan

- [x] `npm run lint && npm run typecheck && npm test` — all pass (39 files, 343 tests)
- [x] Live test: `ask "prompt" --detach` — job completes, prompt in `prompt.txt` not in argv/job.json
- [x] Codex review — P1/P2 findings fixed (backwards compat + race condition)

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * プロンプトデータの処理方式を内部的に改善しました。コマンドライン引数ベースから専用フィールドベースへの移行により、プロンプトの受け渡しと保存が最適化されました。
  * ジョブ実行時のプロンプト管理メカニズムを更新し、より堅牢な運用を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->