### PR TITLE
docs: update README for v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ cavendish deep-research --export pdf "State of WebAssembly in 2026"
 npm install -g cavendish
 ```
 
+Update to the latest version:
+
+```bash
+npm update -g cavendish
+```
+
 ## Quick Start
 
 Cavendish uses a **dedicated Chrome profile** stored in `~/.cavendish/chrome-profile`. Your regular Chrome profile is not affected.


### PR DESCRIPTION
## Summary
- Replace old model names (GPT-4o, o1-pro, o3-mini-high) with current ChatGPT model picker names (Pro, Thinking)
- Add ChatGPT Pro to prerequisites
- Document batch delete/archive/move and `--stdin` flag
- Add `--upload-timeout` to common options table
- Fix year 2025 → 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * バッチ操作（削除、アーカイブ、移動）をサポート、stdin経由のバッチ読み取り/パイプ利用例を追加
  * マルチモデル表記を更新（Pro、Thinking、その他チャットモデル、思考設定対応）

* **オプション**
  * アップロードタイムアウト指定（--upload-timeout）を追加
  * 標準入力読み取り（--stdin）を追加
  * フォーマット指定の適用範囲を拡大

* **ドキュメント**
  * 利用前提・アカウント種別（Pro/Plus/Team/Enterprise）を明記、最新版への更新手順（npm update）を追加

* **修正**
  * 表記の大文字化（pro→Pro）および Deep Research 年表記を2026に更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->