### PR TITLE
fix: update help example year 2025 → 2026

### DIFF
--- a/src/commands/deep-research.ts
+++ b/src/commands/deep-research.ts
@@ -421,7 +421,7 @@ export const deepResearchCommand = defineCommand({
     description:
       'Send a prompt to ChatGPT Deep Research and return the report.\n\n'
       + 'Usage:\n'
-      + '  cavendish deep-research "Compare React vs Vue in 2025"\n'
+      + '  cavendish deep-research "Compare React vs Vue in 2026"\n'
       + '  echo "topic" | cavendish deep-research "Analyze this"\n'
       + '  cavendish deep-research "Follow up" --chat <id>\n'
       + '  cavendish deep-research --chat <id> --refresh\n'


### PR DESCRIPTION
## Summary
- Fix outdated year in deep-research help example: 2025 → 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * deep-research コマンドの使用例を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->