### PR TITLE
fix: prevent false stall detection during long thinking

### DIFF
--- a/src/core/driver/response-handler.ts
+++ b/src/core/driver/response-handler.ts
@@ -166,49 +166,58 @@ async function getResponseSnapshot(
   }
   const messageCount = await page.locator(SELECTORS.ASSISTANT_MESSAGE).count();
 
-  const latest = await page.evaluate(
-    (
-      {
-        messageSelector,
-        copySelector,
-        thinkingSelector,
-        offset,
-      }: {
-        messageSelector: string;
-        copySelector: string;
-        thinkingSelector: string;
-        offset: number;
+  let latest: { text: string; copyButtonVisible: boolean; thinkingText: string };
+  try {
+    latest = await page.evaluate(
+      (
+        {
+          messageSelector,
+          copySelector,
+          thinkingSelector,
+          offset,
+        }: {
+          messageSelector: string;
+          copySelector: string;
+          thinkingSelector: string;
+          offset: number;
+        },
+      ) => {
+        // Prevents false stall detection during long thinking (#194)
+        const thinkingEls = document.querySelectorAll(thinkingSelector);
+        const lastThinking = thinkingEls.length > 0
+          ? thinkingEls[thinkingEls.length - 1]
+          : null;
+        const thinkingText = lastThinking !== null ? lastThinking.textContent.trim() : '';
+
+        const messages = document.querySelectorAll(messageSelector);
+        if (messages.length <= offset) {
+          return { text: '', copyButtonVisible: false, thinkingText };
+        }
+
+        const target = messages[messages.length - 1];
+        const text = target.textContent.trim();
+        // The copy button lives in the enclosing <article>, not inside the
+        // assistant message element itself (ChatGPT DOM change, Chrome 145+).
+        const article = target.closest('article');
+        const copyButton = (article ?? target).querySelector<HTMLElement>(copySelector);
+        const copyButtonVisible = copyButton !== null && copyButton.getBoundingClientRect().height > 0;
+
+        return { text, copyButtonVisible, thinkingText };
       },
-    ) => {
-      // Prevents false stall detection during long thinking (#194)
-      const thinkingEls = document.querySelectorAll(thinkingSelector);
-      const lastThinking = thinkingEls.length > 0
-        ? thinkingEls[thinkingEls.length - 1]
-        : null;
-      const thinkingText = lastThinking !== null ? lastThinking.textContent.trim() : '';
-
-      const messages = document.querySelectorAll(messageSelector);
-      if (messages.length <= offset) {
-        return { text: '', copyButtonVisible: false, thinkingText };
-      }
-
-      const target = messages[messages.length - 1];
-      const text = target.textContent.trim();
-      // The copy button lives in the enclosing <article>, not inside the
-      // assistant message element itself (ChatGPT DOM change, Chrome 145+).
-      const article = target.closest('article');
-      const copyButton = (article ?? target).querySelector<HTMLElement>(copySelector);
-      const copyButtonVisible = copyButton !== null && copyButton.getBoundingClientRect().height > 0;
-
-      return { text, copyButtonVisible, thinkingText };
-    },
-    {
-      messageSelector: SELECTORS.ASSISTANT_MESSAGE,
-      copySelector: SELECTORS.COPY_BUTTON,
-      thinkingSelector: SELECTORS.THINKING_INDICATOR,
-      offset: previousCount,
-    },
-  );
+      {
+        messageSelector: SELECTORS.ASSISTANT_MESSAGE,
+        copySelector: SELECTORS.COPY_BUTTON,
+        thinkingSelector: SELECTORS.THINKING_INDICATOR,
+        offset: previousCount,
+      },
+    );
+  } catch (error: unknown) {
+    throw new CavendishError(
+      `Failed to read response snapshot (selectors: ${SELECTORS.ASSISTANT_MESSAGE}, ${SELECTORS.COPY_BUTTON}, ${SELECTORS.THINKING_INDICATOR}, offset: ${String(previousCount)}): ${errorMessage(error)}`,
+      'selector_miss',
+      'Run "cavendish status" to verify selectors and inspect the ChatGPT tab for UI changes.',
+    );
+  }
 
   return {
     text: latest.text,

--- a/tests/response-handler.test.ts
+++ b/tests/response-handler.test.ts
@@ -248,6 +248,40 @@ describe('waitForResponse()', () => {
     }
   });
 
+  it('does not stall when assistant message leads and thinking text changes before stop button (#194)', async () => {
+    const { waitForResponse } = await import('../src/core/driver/response-handler.js');
+    const now = vi.spyOn(Date, 'now');
+    let tick = 0;
+    now.mockImplementation(() => {
+      tick += 3_000;
+      return tick;
+    });
+
+    try {
+      const page = new FakePage([
+        { text: '', count: 0, stopVisible: false, copyVisible: false },
+        { text: 'Partial answer', count: 1, stopVisible: false, copyVisible: false, thinkingText: 'Thinking step 1...' },
+        { text: 'Partial answer', count: 1, stopVisible: true, copyVisible: false, thinkingText: 'Thinking step 1... step 2...' },
+        { text: 'Partial answer', count: 1, stopVisible: true, copyVisible: false, thinkingText: 'Thinking step 1... step 2... step 3...' },
+        { text: 'Final answer', count: 1, stopVisible: false, copyVisible: true },
+      ]) as unknown as Parameters<typeof waitForResponse>[0];
+
+      const result = await waitForResponse(page, {
+        timeout: 60_000,
+        stallTimeoutMs: 5_000,
+        initialMsgCount: 0,
+        quiet: true,
+      });
+
+      expect(result).toEqual({
+        text: 'Final answer',
+        completed: true,
+      });
+    } finally {
+      now.mockRestore();
+    }
+  });
+
   it('times out when activity stalls while the stop button remains visible', async () => {
     const { waitForResponse } = await import('../src/core/driver/response-handler.js');
     const now = vi.spyOn(Date, 'now');


### PR DESCRIPTION
## Summary

- Monitor `.agent-turn` text changes in `ResponseSnapshot` so that thinking/reasoning activity resets the stall timer, preventing false `Response stalled for Xs` errors during long model thinking
- Scoped to the last `.agent-turn` element only (avoids past-turn false positives and reduces per-poll overhead)
- Added regression test verifying thinking text changes prevent stall detection

## Details

The stall detector in `response-handler.ts` tracked 4 DOM signals: assistant message text, message count, stop button visibility, and copy button visibility. During extended thinking (e.g., Thinking model with deep effort), none of these change — the model's reasoning appears in `.agent-turn` elements which were not monitored. This caused false stall timeout errors (exit code 7).

### Changes

| File | Change |
|---|---|
| `src/core/driver/response-handler.ts` | Add `thinkingText` to `ResponseSnapshot`, capture last `.agent-turn` textContent in `getResponseSnapshot()`, include in `snapshotChanged()` |
| `tests/response-handler.test.ts` | Add `thinkingText` to `FakePage`, add test for thinking-active-no-stall scenario |

### Scope check

| Feature | Uses stall detection? | Affected? |
|---|---|---|
| `ask` (all models) | Yes (`response-handler.ts`) | Fixed |
| Agent mode | Yes (same `waitForResponse`) | Fixed (`.agent-turn` covers agent processing steps) |
| Deep Research | No (own polling logic) | Not affected |

### Verification

- `npm run lint` / `npm run typecheck` / `npm test` — all pass (367 tests)
- Live test: `--model thinking --timeout 600` with deep reasoning prompt — completed without stall error

Closes #194

@coderabbitai full review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * レスポンススナップショットに「thinkingText」フィールドを追加し、表示中の思考テキストを取得・比較対象に含めるようになりました。
* **バグ修正**
  * スナップショット読み取り時の例外処理を強化し、診断情報を改善しました。
* **テスト**
  * 思考テキストの変化による待機処理の挙動を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->