### PR TITLE
docs: add disclaimer section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ cat src/app.ts | cavendish ask --model Pro "Review this code"
 cavendish deep-research --export pdf "State of WebAssembly in 2026"
 ```
 
+## Disclaimer
+
+> **This tool automates ChatGPT's Web UI using browser automation and may violate [OpenAI's Terms of Use](https://openai.com/policies/terms-of-use/). Its availability does not guarantee compliance with those terms. Use at your own risk.**
+>
+> This tool requires a valid ChatGPT paid subscription (Pro, Plus, Team, or Enterprise) and does not bypass any payment or authentication. It exists primarily to provide programmatic access to features not yet available through OpenAI's official API, such as Deep Research. If OpenAI releases official API support for these features, we recommend migrating to the official API.
+
 ## Features
 
 - **Multi-model support** — Pro, Thinking, and other ChatGPT models with configurable thinking effort


### PR DESCRIPTION
## Summary
- Add a Disclaimer section to README clarifying that this tool automates ChatGPT's Web UI and may violate OpenAI's Terms of Use
- Note that a paid subscription is required and no payment/auth is bypassed
- Clarify the tool's purpose as programmatic access to features not yet available via official API (e.g. Deep Research)
- Recommend migration to official API once available

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * README にディスクレイマーセクションを追加しました。ブラウザ自動化の利用に関する重要な警告、有効な有料サブスクリプションの要件、および公式 API への移行に関する情報を含みます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->