### PR TITLE
fix: update file input and conversation turn selectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavendish",
-  "version": "1.0.2",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavendish",
-      "version": "1.0.2",
+      "version": "1.1.2",
       "license": "ISC",
       "dependencies": {
         "citty": "^0.2.1",

--- a/src/constants/selectors.ts
+++ b/src/constants/selectors.ts
@@ -25,8 +25,8 @@ export const SELECTORS = {
   MODEL_MENUITEM: '[role="menuitem"]:not([data-has-submenu])',
 
   // ── File attachment ──────────────────────────────────────
-  /** Hidden file input (no id attribute) */
-  FILE_INPUT_GENERIC: 'input[type="file"]:not([id])',
+  /** Hidden file input for general file uploads (ChatGPT assigns id="upload-files") */
+  FILE_INPUT_GENERIC: '#upload-files',
 
   /** File tile that appears in the composer after a file is attached.
    *  Uses the Tailwind group name which is specific to file tiles. */
@@ -45,8 +45,8 @@ export const SELECTORS = {
   /** Any descendant that explicitly exposes a message role */
   MESSAGE_ROLE_NODE: '[data-message-author-role]',
 
-  /** Broad fallback for rendered conversation turns when role attributes drift */
-  CONVERSATION_TURN: 'main article',
+  /** Fallback for rendered conversation turns, matched via data-testid prefix */
+  CONVERSATION_TURN: 'main section[data-testid^="conversation-turn"]',
 
   /** Attachment tile still uploading (live DOM: remove button has cursor-wait) */
   UPLOAD_IN_PROGRESS: '.group\\/file-tile button.cursor-wait',


### PR DESCRIPTION
## Summary

- `FILE_INPUT_GENERIC` セレクタを `input[type="file"]:not([id])` → `#upload-files` に更新（ChatGPT が file input に `id="upload-files"` を付与するようになったため）
- `CONVERSATION_TURN` セレクタを `main article` → `main section[data-testid^="conversation-turn"]` に更新（会話ターンが `data-testid` 付き `section` に変更されたため）

Closes #199

## Test plan

- [x] `cavendish ask --file <path> "prompt"` でファイル添付が成功することを確認
- [x] `cavendish ask "prompt"` でテキストのみの送信が引き続き動作することを確認
- [x] `npm run lint && npm run typecheck && npm test` 全パス（368テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ファイルアップロード機能とメッセージ表示領域のセレクタの精度を向上させ、要素の検出をより確実にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->