### PR TITLE
feat(cli): improve detached job wait ergonomics

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,6 +3,7 @@ language: "en-US"
 
 reviews:
   profile: assertive
+  request_changes_workflow: true
   review_status: true
   auto_review:
     enabled: true


### PR DESCRIPTION
## Summary
- add a top-level `cavendish wait <job-id>` alias that reuses `jobs wait`
- add `--poll <seconds>` to `jobs wait` / `wait` so long-running detached jobs can emit keepalive status to stderr without breaking stdout payloads
- clarify detach-first behavior and the recommended long-running workflow in the README
- add regression tests for the new alias and polling behavior

Closes #209

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `node dist/index.mjs report --format json` *(blocked by another running cavendish process holding the lock: PID 1260)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined code-review configuration to scope analysis and apply tailored guidance by file type.
  * Updated priority label wording for readability/maintainability.
  * Strengthened test requirements: determinism, decisive assertions, no disabling/deleting, and mandatory bug-fix tests that reproduce failures.
  * Added checks for documentation clarity/consistency and for configuration schema/alignment and CI impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->