### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -94,15 +94,15 @@ async function waitForTerminalJob(
   let nextProgressAt = pollIntervalMs !== undefined ? Date.now() : undefined;
   while (Date.now() < deadline) {
     const job = readJobOrThrow(jobId);
+    if (job.status === 'completed' || job.status === 'failed' || job.status === 'timed_out' || job.status === 'cancelled') {
+      return job;
+    }
     if (pollIntervalMs !== undefined && nextProgressAt !== undefined && Date.now() >= nextProgressAt) {
       progress(
         `Waiting for detached job ${job.jobId} (status: ${job.status}, retries: ${String(job.retryCount)})`,
         quiet,
       );
       nextProgressAt = Date.now() + pollIntervalMs;
-    }
-    if (job.status === 'completed' || job.status === 'failed' || job.status === 'timed_out' || job.status === 'cancelled') {
-      return job;
     }
     await new Promise((resolve) => {
       setTimeout(resolve, 200);

--- a/tests/jobs-command.test.ts
+++ b/tests/jobs-command.test.ts
@@ -194,30 +194,37 @@ describe('jobs command', () => {
     try {
       const { jobsCommand } = await import('../src/commands/jobs.js');
       const store = await import('../src/core/jobs/store.js');
-      vi.mocked(store.readJob)
-        .mockReturnValueOnce({
-          jobId: 'job-1',
-          kind: 'ask',
-          status: 'running',
-          submittedAt: '2026-03-14T00:00:00.000Z',
-          updatedAt: '2026-03-14T00:00:00.000Z',
-          retryCount: 0,
-        } as never)
-        .mockReturnValueOnce({
-          jobId: 'job-1',
-          kind: 'ask',
-          status: 'completed',
-          submittedAt: '2026-03-14T00:00:00.000Z',
-          updatedAt: '2026-03-14T00:00:01.000Z',
-          retryCount: 0,
-        } as never);
+      const runningJob = {
+        jobId: 'job-1',
+        kind: 'ask',
+        status: 'running',
+        submittedAt: '2026-03-14T00:00:00.000Z',
+        updatedAt: '2026-03-14T00:00:00.000Z',
+        retryCount: 0,
+      } as never;
+      const completedJob = {
+        jobId: 'job-1',
+        kind: 'ask',
+        status: 'completed',
+        submittedAt: '2026-03-14T00:00:00.000Z',
+        updatedAt: '2026-03-14T00:00:02.000Z',
+        retryCount: 0,
+      } as never;
+      // Return running for many iterations, then completed after ~2.2s
+      // (each loop iteration sleeps 200ms, so 11 iterations ≈ 2.2s)
+      const readJobMock = vi.mocked(store.readJob);
+      for (let i = 0; i < 11; i++) {
+        readJobMock.mockReturnValueOnce(runningJob);
+      }
+      readJobMock.mockReturnValue(completedJob);
+
       vi.mocked(store.readJobResult).mockReturnValue({
         event: {
           content: 'final response',
           model: 'Pro',
           partial: false,
           timeoutSec: 0,
-          timestamp: '2026-03-14T00:00:01.000Z',
+          timestamp: '2026-03-14T00:00:02.000Z',
         },
       } as never);
 
@@ -235,7 +242,7 @@ describe('jobs command', () => {
           _: [],
           jobId: 'job-1',
           poll: '1',
-          timeout: '5',
+          timeout: '10',
           format: 'json',
           quiet: false,
           verbose: false,
@@ -244,10 +251,22 @@ describe('jobs command', () => {
         cmd: waitCommand,
       }));
 
+      // Initial progress fires immediately (nextProgressAt = Date.now()),
+      // then every pollIntervalMs (1000ms). At T=1100: 2 calls (T=0 + T=1000).
       await vi.advanceTimersByTimeAsync(1100);
+      expect(progressMock).toHaveBeenCalledTimes(2);
+      expect(progressMock).toHaveBeenCalledWith(
+        expect.stringContaining('status: running'),
+        false,
+      );
+
+      // Advance past next poll boundary (T=2000ms) — third progress call
+      await vi.advanceTimersByTimeAsync(1100);
+      expect(progressMock).toHaveBeenCalledTimes(3);
+
+      // Job completes after ~2.2s
       await runPromise;
 
-      expect(progressMock).toHaveBeenCalled();
       expect(jsonRawMock).toHaveBeenCalledWith({
         content: 'final response',
         model: 'Pro',
@@ -256,7 +275,7 @@ describe('jobs command', () => {
         project: undefined,
         partial: false,
         timeoutSec: 0,
-        timestamp: '2026-03-14T00:00:01.000Z',
+        timestamp: '2026-03-14T00:00:02.000Z',
       });
     } finally {
       vi.useRealTimers();


### PR DESCRIPTION
## Summary
- Bump version to 2.0.1 for npm publish
- Includes `cavendish wait` top-level alias and `--poll` flag from 8e5f1c1

## Test plan
- [ ] CI passes (lint, typecheck, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal job state handling to process completion states more efficiently.
  * Minimum polling interval for the `wait` command now enforced at 1000ms.

* **Tests**
  * Enhanced test assertions for job polling progress tracking with more granular checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->