### PR TITLE
chore: bump version to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavendish",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A Playwright-based CLI tool that automates ChatGPT's Web UI, enabling coding agents to query ChatGPT Pro models via a single shell command",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary
- Bump version to 2.0.2 for npm publish
- Includes fixes from #212 and #213:
  - Pretty-print JSON output by default (#211)
  - `--poll` minimum 1-second floor
  - Terminal state check before progress log

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.0.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->