### PR TITLE
fix: add concurrency gate to prevent TOCTOU race in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   publish:
+    concurrency:
+      group: publish-${{ github.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/tests/publish-workflow.test.ts
+++ b/tests/publish-workflow.test.ts
@@ -10,4 +10,11 @@ describe('publish workflow', () => {
     expect(workflow).toContain("if: steps.publish_guard.outputs.should_publish == 'true'");
     expect(workflow).toContain('node .github/scripts/check-publish-version.mjs');
   });
+
+  it('serializes parallel publish runs with a concurrency gate', () => {
+    const workflow = readFileSync('.github/workflows/publish.yml', 'utf-8');
+
+    expect(workflow).toContain('group: publish-${{ github.ref }}');
+    expect(workflow).toContain('cancel-in-progress: false');
+  });
 });


### PR DESCRIPTION
## Summary
- publishワークフローにconcurrency gateを追加し、並行tag-triggered runによるTOCTOU raceを防止
- publish-workflowテストにconcurrency gate検証を追加

## Context
PR #216 のCodeRabbitレビューで指摘されたTOCTOU race条件への対応。check→publishシーケンスで並行runが両方チェックをpassし重複publishを試みる可能性を、`concurrency` groupでシリアライズすることで解消。

## Test plan
- [x] `npm test -- tests/publish-workflow.test.ts` pass
- [ ] CI全チェックpass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved publishing workflow reliability by adding concurrency configuration to ensure only one publish operation executes per reference at a time.

* **Tests**
  * Added test coverage to verify publishing workflow concurrency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->