### PR TITLE
fix: recover partial content from timed-out jobs and improve wait output

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ v2.0 changes the default execution model. `ask` and `deep-research` now run **de
 |----------------|--------------|
 | `cavendish ask "..."` blocks and returns response | Returns job metadata (jobId) immediately |
 | `--detach` opt-in for background execution | Default behavior |
-| `--timeout` defaults: ask 120s, Pro 2400s, DR 1800s | Default: unlimited (no timeout) |
+| `--timeout` defaults varied by model (ask 120s, Pro 2400s, DR 1800s) | Default: unlimited for all models (specify `--timeout <sec>` explicitly) |
 | `--stream` + `--detach` rejected | `--stream` implies `--sync` |
 
 ### Migration

--- a/docs/live-test.md
+++ b/docs/live-test.md
@@ -91,6 +91,6 @@ The cavendish profile at `~/.cavendish/chrome-profile` is separate from your reg
 
 ## Notes
 
-- **Timeout**: Pro model needs 60–120s+. Default is 2400s for Pro.
+- **Timeout**: Pro model responses can take 5–20+ minutes. Default is unlimited (no `--timeout`). Specify `--timeout <sec>` explicitly if needed.
 - **Port conflict**: If port 9222 is in use, kill the old process first: `lsof -ti :9222 | xargs kill`.
 - **Cleanup**: Chrome stays running after cavendish exits (by design). Quit gracefully when done.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -209,7 +209,7 @@ cavendish projects --name "For-Agents" --chats
 --format text     # プレーンテキスト
 --format json     # 構造化出力（デフォルト、メタデータ含む）
 --stream          # NDJSONストリーミング出力
---timeout 120     # 秒数指定（デフォルト: 120秒、Pro: 2400秒、DR: 1800秒）
+--timeout 120     # 秒数指定（デフォルト: 無制限。全モデル共通）
 ```
 
 ※ `--format` は `list`, `read`, `projects`, `status` でも利用可能。`doctor` は独自の `--json` フラグを使用。

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -260,6 +260,8 @@ export const waitCommand = defineCommand({
       }
       if (format === 'json') {
         jsonRaw({
+          jobId: job.jobId,
+          status: job.status,
           content: result.event.content,
           model: result.event.model,
           chatId: result.event.chatId,

--- a/src/core/jobs/store.ts
+++ b/src/core/jobs/store.ts
@@ -258,6 +258,36 @@ export function readJobResult(jobId: string): JobResultRecord | undefined {
   return readJsonFile(path, `job result ${jobId}`) as JobResultRecord | undefined;
 }
 
+/**
+ * Scan events.ndjson for the longest content from chunk/final events.
+ * Used to recover partial responses when no final event was emitted
+ * (e.g. stall-timeout where the worker exits before writing a result).
+ */
+export function recoverBestContentFromEvents(jobId: string): string | undefined {
+  const path = getJobEventsPath(jobId);
+  if (!existsSync(path)) {
+    return undefined;
+  }
+  let best: string | undefined;
+  let bestLength = 0;
+  const raw = readFileSync(path, 'utf8');
+  for (const line of raw.split('\n')) {
+    if (line.length === 0) {continue;}
+    try {
+      const parsed = JSON.parse(line) as Record<string, unknown>;
+      if (parsed.type !== 'chunk' && parsed.type !== 'final') {continue;}
+      const content = parsed.content;
+      if (typeof content === 'string' && content.length > bestLength) {
+        best = content;
+        bestLength = content.length;
+      }
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return best;
+}
+
 export function writeJobError(jobId: string, error: StructuredErrorPayload): void {
   writeJsonAtomic(getJobErrorPath(jobId), error);
 }

--- a/src/core/jobs/store.ts
+++ b/src/core/jobs/store.ts
@@ -281,8 +281,9 @@ export function recoverBestContentFromEvents(jobId: string): string | undefined 
         best = content;
         bestLength = content.length;
       }
-    } catch {
-      // skip malformed lines
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`[cavendish:jobs] skipping malformed event line in ${path}: ${message}\n`);
     }
   }
   return best;

--- a/src/core/jobs/worker.ts
+++ b/src/core/jobs/worker.ts
@@ -6,7 +6,7 @@ import { progress } from '../output-handler.js';
 import type { NdjsonEvent } from '../output-handler.js';
 
 import { notifyJobCompletion } from './notifier.js';
-import { appendJobEvent, readJob, readJobPrompt, updateJob, writeJobError, writeJobResult } from './store.js';
+import { appendJobEvent, readJob, readJobPrompt, recoverBestContentFromEvents, updateJob, writeJobError, writeJobResult } from './store.js';
 import type { JobRecord, JobStatus } from './types.js';
 
 export type JobRunOutcome = 'completed' | 'failed' | 'timed_out' | 'retry';
@@ -175,6 +175,18 @@ export async function runJobWorker(jobId: string): Promise<JobRunResult> {
     return { outcome: status, record };
   }
 
+  // Recover partial content from streamed chunks when no final event was
+  // emitted (e.g. stall-timeout).  This ensures result.json is populated
+  // so that `cavendish jobs wait` can return the best available content.
+  const recoveredContent = recoverBestContentFromEvents(jobId);
+  if (recoveredContent !== undefined && recoveredContent.length > 0) {
+    const now = new Date().toISOString();
+    writeJobResult(jobId, {
+      event: { type: 'final', content: recoveredContent, partial: true, timestamp: now },
+      savedAt: now,
+    });
+  }
+
   const errorPayload: StructuredErrorPayload = structuredError ?? {
     error: true,
     category: 'unknown',
@@ -201,11 +213,13 @@ export async function runJobWorker(jobId: string): Promise<JobRunResult> {
 
   writeJobError(jobId, errorPayload);
   const status = terminalStatusFromError(errorPayload);
+  const hasRecoveredContent = recoveredContent !== undefined && recoveredContent.length > 0;
   record = updateJob(jobId, {
     status,
     completedAt: new Date().toISOString(),
     error: errorPayload,
     exitCode: normalizedExitCode,
+    partial: hasRecoveredContent ? true : undefined,
   });
   appendJobState(jobId, `job-${status}`);
   notifyJobCompletion(record);

--- a/tests/jobs-command.test.ts
+++ b/tests/jobs-command.test.ts
@@ -268,6 +268,8 @@ describe('jobs command', () => {
       await runPromise;
 
       expect(jsonRawMock).toHaveBeenCalledWith({
+        jobId: 'job-1',
+        status: 'completed',
         content: 'final response',
         model: 'Pro',
         chatId: undefined,
@@ -280,5 +282,61 @@ describe('jobs command', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('includes jobId and status in wait JSON output for timed_out jobs', async () => {
+    const { jobsCommand } = await import('../src/commands/jobs.js');
+    const store = await import('../src/core/jobs/store.js');
+    vi.mocked(store.readJob).mockReturnValue({
+      jobId: 'job-2',
+      kind: 'ask',
+      status: 'timed_out',
+      submittedAt: '2026-03-14T00:00:00.000Z',
+      updatedAt: '2026-03-14T00:01:00.000Z',
+      retryCount: 0,
+      partial: true,
+    } as never);
+    vi.mocked(store.readJobResult).mockReturnValue({
+      event: {
+        type: 'final',
+        content: 'partial response text',
+        model: 'Pro',
+        partial: true,
+        timeoutSec: 600,
+        timestamp: '2026-03-14T00:01:00.000Z',
+      },
+    } as never);
+    vi.mocked(store.readJobError).mockReturnValue(undefined);
+
+    const subCommands = jobsCommand.subCommands as unknown as {
+      wait?: RunnableCommand;
+    };
+    const waitCommand = subCommands.wait;
+    const run = waitCommand?.run;
+    if (waitCommand === undefined || run === undefined) {
+      throw new Error('jobsCommand.subCommands.wait.run is undefined');
+    }
+
+    await run({
+      args: {
+        _: [],
+        jobId: 'job-2',
+        timeout: '5',
+        format: 'json',
+        quiet: false,
+        verbose: false,
+      } as never,
+      rawArgs: [],
+      cmd: waitCommand,
+    });
+
+    expect(jsonRawMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: 'job-2',
+        status: 'timed_out',
+        content: 'partial response text',
+        partial: true,
+      }),
+    );
   });
 });

--- a/tests/jobs-store.test.ts
+++ b/tests/jobs-store.test.ts
@@ -119,6 +119,31 @@ describe('job store', () => {
     expect(readNextQueuedJob()?.jobId).toBe(job.jobId);
   });
 
+  it('recovers the longest chunk content from events.ndjson', async () => {
+    const { appendJobEvent, createJob, recoverBestContentFromEvents } = await importWithMockedHome();
+    const job = createJob({ kind: 'ask', argv: ['ask', 'hello'] });
+    appendJobEvent(job.jobId, JSON.stringify({ type: 'chunk', content: 'Hello', timestamp: '2026-01-01T00:00:00Z' }));
+    appendJobEvent(job.jobId, JSON.stringify({ type: 'chunk', content: 'Hello world', timestamp: '2026-01-01T00:00:01Z' }));
+    appendJobEvent(job.jobId, JSON.stringify({ type: 'chunk', content: 'Hello world, how are you?', timestamp: '2026-01-01T00:00:02Z' }));
+    appendJobEvent(job.jobId, JSON.stringify({ type: 'state', state: 'job-running', content: '', timestamp: '2026-01-01T00:00:03Z' }));
+
+    expect(recoverBestContentFromEvents(job.jobId)).toBe('Hello world, how are you?');
+  });
+
+  it('returns undefined when events.ndjson has no chunk or final events', async () => {
+    const { appendJobEvent, createJob, recoverBestContentFromEvents } = await importWithMockedHome();
+    const job = createJob({ kind: 'ask', argv: ['ask', 'hello'] });
+    appendJobEvent(job.jobId, JSON.stringify({ type: 'state', state: 'job-running', content: '', timestamp: '2026-01-01T00:00:00Z' }));
+
+    expect(recoverBestContentFromEvents(job.jobId)).toBeUndefined();
+  });
+
+  it('returns undefined when events.ndjson does not exist', async () => {
+    const { recoverBestContentFromEvents } = await importWithMockedHome();
+
+    expect(recoverBestContentFromEvents('00000000-0000-4000-8000-000000000001')).toBeUndefined();
+  });
+
   it('skips job files that deserialize to null', async () => {
     const { createJob, getJobsDir, getJobFilePath, readNextQueuedJob } = await importWithMockedHome();
     const job = createJob({

--- a/tests/jobs-worker.test.ts
+++ b/tests/jobs-worker.test.ts
@@ -144,6 +144,38 @@ describe('job worker', () => {
     expect(store.readJobError(job.jobId)?.category).toBe('timeout');
   });
 
+  it('recovers partial content from chunk events when no final event is emitted', async () => {
+    const chunk1 = JSON.stringify({ type: 'chunk', content: 'Hello', timestamp: '2026-01-01T00:00:00Z' });
+    const chunk2 = JSON.stringify({ type: 'chunk', content: 'Hello world', timestamp: '2026-01-01T00:00:01Z' });
+    const chunk3 = JSON.stringify({ type: 'chunk', content: 'Hello world, this is partial', timestamp: '2026-01-01T00:00:02Z' });
+    const errorLine = JSON.stringify({
+      error: true,
+      category: 'timeout',
+      message: 'Response stalled',
+      exitCode: 7,
+      action: 'retry',
+    });
+    const { store, worker } = await importWithMocks(() => makeChild(
+      [chunk1, chunk2, chunk3],
+      [errorLine],
+      7,
+    ));
+    const job = store.createJob({
+      kind: 'ask',
+      argv: ['ask', 'hello'],
+    });
+
+    const result = await worker.runJobWorker(job.jobId);
+
+    expect(result.outcome).toBe('timed_out');
+    const savedResult = store.readJobResult(job.jobId);
+    expect(savedResult).toBeDefined();
+    expect(savedResult?.event.content).toBe('Hello world, this is partial');
+    expect(savedResult?.event.partial).toBe(true);
+    // JobRecord.partial must match result.json for notification consistency
+    expect(store.readJob(job.jobId)?.partial).toBe(true);
+  });
+
   it('propagates a non-zero exit code for failed worker runs', async () => {
     const errorLine = JSON.stringify({
       error: true,


### PR DESCRIPTION
## Summary

Closes #218, #219, #220

- **#219**: `cavendish jobs wait --format json` に `jobId` と `status` フィールドを追加。呼び出し元が別ファイルをパースせずにジョブの状態を取得可能に
- **#220**: worker が final イベントなしで終了した場合（stall-timeout 等）、`events.ndjson` から最長の部分コンテンツを回復して `result.json` に保存。`jobs wait` が最善のコンテンツを返せるように
- **#218**: タイムアウトのドキュメントを修正。全モデル共通でデフォルトは無制限（unlimited）であることを明記し、モデル別デフォルトへの古い参照を削除

## Test plan

- [x] `npm run lint` — zero errors
- [x] `npm run typecheck` — zero errors
- [x] `npm test` — 410 tests passed (新規テスト含む)
  - `recoverBestContentFromEvents`: 最長チャンク回復、空ファイル、state-only イベント
  - worker: チャンクイベントからの部分コンテンツ回復、`JobRecord.partial` 整合性
  - wait: `jobId`/`status` 出力、`timed_out` ジョブの JSON 出力

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guide and documentation to clarify that `--timeout` defaults to unlimited; explicit flag required to impose a limit.

* **Bug Fixes**
  * Improved job result reporting: JSON output now includes job ID and status fields.
  * Enhanced recovery of partial job results when operations are interrupted, preventing data loss.

* **Tests**
  * Added test coverage for job result output and partial result recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->