### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavendish",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A Playwright-based CLI tool that automates ChatGPT's Web UI, enabling coding agents to query ChatGPT Pro models via a single shell command",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

- Patch version bump for #221 (fix: recover partial content from timed-out jobs and improve wait output)

After merge, tag `v2.1.1` to trigger npm publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)