### PR TITLE
fix(model-picker): support radio menu items in ChatGPT DOM

### DIFF
--- a/src/constants/selectors.ts
+++ b/src/constants/selectors.ts
@@ -21,8 +21,8 @@ export const SELECTORS = {
   /** Model picker dropdown menu */
   MODEL_MENU: '[role="menu"]',
 
-  /** Individual model option (excludes submenu triggers like Legacy models) */
-  MODEL_MENUITEM: '[role="menuitem"]:not([data-has-submenu])',
+  /** Individual model option (supports current radio-style model entries and excludes submenu triggers) */
+  MODEL_MENUITEM: ':is([role="menuitem"], [role="menuitemradio"]):not([data-has-submenu])',
 
   // ── File attachment ──────────────────────────────────────
   /** Hidden file input for general file uploads (ChatGPT assigns id="upload-files") */

--- a/tests/model-picker.test.ts
+++ b/tests/model-picker.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SELECTORS } from '../src/constants/selectors.js';
+import { ChatGPTDriver } from '../src/core/chatgpt-driver.js';
+
+interface FakeModelOption {
+  text: string;
+  clicked: boolean;
+}
+
+class FakeModelItemsLocator {
+  constructor(private readonly items: FakeModelOption[]) {}
+
+  filter({ hasText }: { hasText: string }): FakeModelItemsLocator {
+    return new FakeModelItemsLocator(this.items.filter((item) => item.text.includes(hasText)));
+  }
+
+  async count(): Promise<number> {
+    return this.items.length;
+  }
+
+  first(): FakeModelItemsLocator {
+    return new FakeModelItemsLocator(this.items.slice(0, 1));
+  }
+
+  async click(): Promise<void> {
+    const [item] = this.items;
+    if (item === undefined) {
+      throw new Error('No model item to click');
+    }
+    item.clicked = true;
+  }
+}
+
+class FakeModelMenuLocator {
+  constructor(private readonly items: FakeModelOption[]) {}
+
+  async waitFor(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  first(): FakeModelMenuLocator {
+    return this;
+  }
+
+  locator(selector: string): FakeModelItemsLocator {
+    if (selector.includes('menuitemradio')) {
+      return new FakeModelItemsLocator(this.items);
+    }
+    return new FakeModelItemsLocator([]);
+  }
+}
+
+class FakeClickableLocator {
+  async click(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async waitFor(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe('ChatGPTDriver.selectModel()', () => {
+  it('selects model picker radio items from the current ChatGPT DOM', async () => {
+    const options: FakeModelOption[] = [
+      { text: 'Instant', clicked: false },
+      { text: 'Thinking', clicked: false },
+      { text: 'Pro', clicked: false },
+    ];
+
+    const page = {
+      locator: vi.fn((selector: string) => {
+        if (selector === SELECTORS.PROMPT_INPUT || selector === SELECTORS.MODEL_SELECTOR_BUTTON) {
+          return new FakeClickableLocator();
+        }
+        if (selector === SELECTORS.MODEL_MENU) {
+          return new FakeModelMenuLocator(options);
+        }
+        throw new Error(`Unexpected selector: ${selector}`);
+      }),
+      keyboard: {
+        press: vi.fn().mockResolvedValue(undefined),
+      },
+    } as const;
+
+    const driver = new ChatGPTDriver(page as never);
+    vi.spyOn(driver, 'waitForReady').mockResolvedValue(undefined);
+    vi.spyOn(driver as never, 'waitForModelMenuStable').mockResolvedValue({
+      populated: true,
+      stabilized: true,
+    });
+
+    await driver.selectModel('Pro', true);
+
+    expect(options[2]?.clicked).toBe(true);
+  });
+});

--- a/tests/model-picker.test.ts
+++ b/tests/model-picker.test.ts
@@ -15,7 +15,7 @@ class FakeModelItemsLocator {
     return new FakeModelItemsLocator(this.items.filter((item) => item.text.includes(hasText)));
   }
 
-  async count(): Promise<number> {
+  count(): Promise<number> {
     return this.items.length;
   }
 
@@ -23,12 +23,13 @@ class FakeModelItemsLocator {
     return new FakeModelItemsLocator(this.items.slice(0, 1));
   }
 
-  async click(): Promise<void> {
-    const [item] = this.items;
+  click(): Promise<void> {
+    const item = this.items.at(0);
     if (item === undefined) {
       throw new Error('No model item to click');
     }
     item.clicked = true;
+    return Promise.resolve();
   }
 }
 
@@ -39,7 +40,7 @@ class FakeModelMenuLocator {
     return Promise.resolve();
   }
 
-  first(): FakeModelMenuLocator {
+  first(): this {
     return this;
   }
 

--- a/tests/model-picker.test.ts
+++ b/tests/model-picker.test.ts
@@ -1,3 +1,4 @@
+import type { Page } from 'playwright-core';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SELECTORS } from '../src/constants/selectors.js';
@@ -31,12 +32,28 @@ class FakeModelItemsLocator {
     item.clicked = true;
     return Promise.resolve();
   }
+
+  evaluateAll<T>(fn: (els: { getAttribute(name: string): string | null; textContent: string }[]) => T): Promise<T> {
+    return Promise.resolve(
+      fn(
+        this.items.map((item, index) => ({
+          getAttribute: (name: string): string | null => {
+            if (name === 'data-testid') {
+              return `model-${String(index)}`;
+            }
+            return null;
+          },
+          textContent: item.text,
+        })),
+      ),
+    );
+  }
 }
 
 class FakeModelMenuLocator {
   constructor(private readonly items: FakeModelOption[]) {}
 
-  async waitFor(): Promise<void> {
+  waitFor(): Promise<void> {
     return Promise.resolve();
   }
 
@@ -53,11 +70,11 @@ class FakeModelMenuLocator {
 }
 
 class FakeClickableLocator {
-  async click(): Promise<void> {
+  click(): Promise<void> {
     return Promise.resolve();
   }
 
-  async waitFor(): Promise<void> {
+  waitFor(): Promise<void> {
     return Promise.resolve();
   }
 }
@@ -85,12 +102,8 @@ describe('ChatGPTDriver.selectModel()', () => {
       },
     } as const;
 
-    const driver = new ChatGPTDriver(page as never);
+    const driver = new ChatGPTDriver(page as unknown as Page);
     vi.spyOn(driver, 'waitForReady').mockResolvedValue(undefined);
-    vi.spyOn(driver as never, 'waitForModelMenuStable').mockResolvedValue({
-      populated: true,
-      stabilized: true,
-    });
 
     await driver.selectModel('Pro', true);
 

--- a/tests/model-picker.test.ts
+++ b/tests/model-picker.test.ts
@@ -16,7 +16,7 @@ class FakeModelItemsLocator {
   }
 
   count(): Promise<number> {
-    return this.items.length;
+    return Promise.resolve(this.items.length);
   }
 
   first(): FakeModelItemsLocator {


### PR DESCRIPTION
## Summary
- support ChatGPT model picker entries that render as `role=\"menuitemradio\"` so CLI model selection keeps working
- add a regression test covering the current model picker DOM shape
- verify the fix with unit tests, build, and live ChatGPT `doctor`/`report`/`ask` checks

## Verification
- `npm test`
- `npm run build`
- `node dist/index.mjs doctor --json`
- `node dist/index.mjs report --format json`
- `node dist/index.mjs ask --sync --format json --timeout 180 \"Reply with exactly OK.\"`
- `node dist/index.mjs ask --sync --file ./README.md --format json --timeout 240 \"Reply with exactly FILE_OK if you received the file.\"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection compatibility by extending support to both standard and radio-style menu items, ensuring consistent behavior across different menu configurations.

* **Tests**
  * Added comprehensive test coverage for model selection functionality to validate reliable operation across varying menu item styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->