### PR TITLE
chore: bump version to 2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavendish",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavendish",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "ISC",
       "dependencies": {
         "citty": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavendish",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A Playwright-based CLI tool that automates ChatGPT's Web UI, enabling coding agents to query ChatGPT Pro models via a single shell command",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary
- bump the package version from 2.1.1 to 2.1.2 based on the unreleased patch-level commits after v2.1.1
- keep `package-lock.json` aligned with `package.json` for the next npm publish
- prepare the repository for the v2.1.2 release tag after merge

## Test Plan
- npm run typecheck
- npm test
- npm run build
- node .github/scripts/check-publish-version.mjs
- note: local `npm run lint` in this workspace hits existing `.worktrees/chore-deadcode-hygiene/*` parsing errors unrelated to this diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.1.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->