### PR TITLE
ci: tighten deadcode enforcement for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
+      - name: Dead code check
+        run: npm run deadcode:ci
+
       - name: Test
         run: npm test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,12 +14,13 @@
 - `tests/`: Vitest regression tests covering behaviors such as CDP handling, `doctor`, `init --reset`, unknown flags, and process locking.
 - `docs/plan.md`: Project plan and a structured overview of commands and design.
 - `docs/live-test.md`: Manual verification steps using a real Chrome / ChatGPT session, including CDP and dedicated profile assumptions.
-- `.github/workflows/ci.yml`: CI workflow. Runs `lint`, `typecheck`, `test`, and `build` on Ubuntu, then runs `test` on macOS and Windows.
+- `.github/workflows/ci.yml`: CI workflow. Runs `lint`, `typecheck`, `deadcode:ci`, `test`, and `build` on Ubuntu, then runs `test` on macOS and Windows.
 
 ## HOW
 
-- Runtime requirements are Node.js 20+, Google Chrome stable, and npm. The main scripts are `npm run build`, `npm run lint`, `npm run typecheck`, and `npm test`.
-- `prepublishOnly` runs `lint`, `typecheck`, `test`, and `build` in that order.
+- Runtime requirements are Node.js 20+, Google Chrome stable, and npm. The main scripts are `npm run build`, `npm run lint`, `npm run typecheck`, `npm run deadcode`, and `npm test`.
+- `prepublishOnly` runs `lint`, `typecheck`, `deadcode`, `test`, and `build` in that order.
+- The publish workflow runs `deadcode:ci` explicitly before `npm publish --ignore-scripts`, so release automation does not rely on npm lifecycle hooks for dead code enforcement.
 - Chrome uses the dedicated profile at `~/.cavendish/chrome-profile` rather than the default profile. CDP metadata is stored in `~/.cavendish/cdp-endpoint.json`.
 - `doctor` / `status` are the main entry points for checking CDP, auth, selectors, and integration health. Changes around browser connectivity or authentication should be validated through that path.
 - For real-browser-dependent changes, `docs/live-test.md` is the baseline procedure. Session persistence assumes graceful Chrome shutdown rather than force-killing processes.

--- a/README.md
+++ b/README.md
@@ -279,8 +279,11 @@ npm run build        # Build (tsup -> dist/index.mjs)
 npm run dev          # Watch mode
 npm run typecheck    # Type check (tsc --noEmit)
 npm run lint         # Lint (ESLint)
+npm run deadcode     # Dead code / unused dependency check (Knip)
 npm test             # Run tests (vitest)
 ```
+
+CI enforces the dead code check with `npm run deadcode:ci`, and the publish workflow runs the same check explicitly before `npm publish --ignore-scripts`.
 
 <details>
 <summary>Project Structure</summary>

--- a/knip.json
+++ b/knip.json
@@ -1,8 +1,15 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
+  "entry": [
+    "src/**/*.ts",
+    "tests/**/*.ts",
+    ".github/scripts/**/*.mjs",
+    "*.config.ts"
+  ],
   "project": [
     "src/**/*.ts",
     "tests/**/*.ts",
+    ".github/scripts/**/*.mjs",
     "*.config.ts"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "eslint-import-resolver-typescript": "^4.4.0",
         "eslint-plugin-import-x": "^4.16.0",
         "eslint-plugin-sonarjs": "^4.0.0",
-        "jiti": "^2.6.1",
         "knip": "^6.0.0",
         "tsup": "^8.4.0",
         "typescript": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "eslint-import-resolver-typescript": "^4.4.0",
     "eslint-plugin-import-x": "^4.16.0",
     "eslint-plugin-sonarjs": "^4.0.0",
-    "jiti": "^2.6.1",
     "knip": "^6.0.0",
     "tsup": "^8.4.0",
     "typescript": "^5.9.0",

--- a/tests/publish-workflow.test.ts
+++ b/tests/publish-workflow.test.ts
@@ -11,6 +11,14 @@ describe('publish workflow', () => {
     expect(workflow).toContain('node .github/scripts/check-publish-version.mjs');
   });
 
+  it('runs the dead code check before publishing with ignored npm scripts', () => {
+    const workflow = readFileSync('.github/workflows/publish.yml', 'utf-8');
+
+    expect(workflow).toContain('name: Dead code check');
+    expect(workflow).toContain('run: npm run deadcode:ci');
+    expect(workflow).toContain('run: npm publish --ignore-scripts');
+  });
+
   it('serializes parallel publish runs with a concurrency gate', () => {
     const workflow = readFileSync('.github/workflows/publish.yml', 'utf-8');
 

--- a/tests/publish-workflow.test.ts
+++ b/tests/publish-workflow.test.ts
@@ -17,6 +17,13 @@ describe('publish workflow', () => {
     expect(workflow).toContain('name: Dead code check');
     expect(workflow).toContain('run: npm run deadcode:ci');
     expect(workflow).toContain('run: npm publish --ignore-scripts');
+
+    const deadcodeIndex = workflow.indexOf('run: npm run deadcode:ci');
+    const publishIndex = workflow.indexOf('run: npm publish --ignore-scripts');
+
+    expect(deadcodeIndex).toBeGreaterThan(-1);
+    expect(publishIndex).toBeGreaterThan(-1);
+    expect(deadcodeIndex).toBeLessThan(publishIndex);
   });
 
   it('serializes parallel publish runs with a concurrency gate', () => {


### PR DESCRIPTION
## Summary
- expand Knip's analysis scope to cover workflow helper scripts and remove the unused `jiti` dependency so deadcode checks pass on the current baseline
- require the publish workflow to run `npm run deadcode:ci` before `npm publish --ignore-scripts`, and lock that behavior with a regression test
- align README and AGENTS guidance with the actual deadcode checks used in CI and release automation

## Test Plan
- npm run lint
- npm run typecheck
- npm run deadcode:ci
- npx vitest run tests/publish-workflow.test.ts
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added dead-code detection to CI and publish workflows
  * Removed an unused development dependency
  * Expanded project analysis scope for code-quality tooling

* **Documentation**
  * Updated development and publishing guides to reflect the new dead-code checks and publish sequence

* **Tests**
  * Added a validation test to ensure the publish workflow includes the dead-code check and runs before publishing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->