### PR TITLE
fix: harden detached jobs + clarify browser/runner failures (#227 #228 #229)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint:fix": "eslint . --fix",
     "deadcode": "knip --files --dependencies --reporter symbols",
     "deadcode:ci": "knip --files --dependencies --reporter github-actions",
-    "test": "vitest run",
+    "test": "vitest run --configLoader runner",
     "test:watch": "vitest",
     "prepublishOnly": "npm run lint && npm run typecheck && npm run deadcode && npm test && npm run build"
   },

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -365,8 +365,8 @@ async function captureInitialFollowUpBaseline(
   };
 }
 
-function submitDetachedAskJob(validated: ValidatedArgs): DetachedSubmitPayload {
-  const record = submitDetachedJob({
+async function submitDetachedAskJob(validated: ValidatedArgs): Promise<DetachedSubmitPayload> {
+  const record = await submitDetachedJob({
     kind: 'ask',
     argv: buildAskJobArgv(validated),
     prompt: validated.prompt,
@@ -384,10 +384,10 @@ function submitDetachedAskJob(validated: ValidatedArgs): DetachedSubmitPayload {
   };
 }
 
-function handleDryRunOrDetach(
+async function handleDryRunOrDetach(
   args: Record<string, unknown>,
   validated: ValidatedArgs,
-): boolean {
+): Promise<boolean> {
   if (args.dryRun === true) {
     progress(dryRunMessage(validated), false);
     return true;
@@ -395,7 +395,7 @@ function handleDryRunOrDetach(
   if (!validated.detach) {
     return false;
   }
-  const payload = submitDetachedAskJob(validated);
+  const payload = await submitDetachedAskJob(validated);
   writeDetachedSubmit(payload, validated.format);
   return true;
 }
@@ -541,7 +541,7 @@ export const askCommand = defineCommand({
     const validated = validateArgs(args);
     if (validated === undefined) {return;}
 
-    if (handleDryRunOrDetach(args, validated)) {
+    if (await handleDryRunOrDetach(args, validated)) {
       return;
     }
 

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -541,7 +541,12 @@ export const askCommand = defineCommand({
     const validated = validateArgs(args);
     if (validated === undefined) {return;}
 
-    if (await handleDryRunOrDetach(args, validated)) {
+    try {
+      if (await handleDryRunOrDetach(args, validated)) {
+        return;
+      }
+    } catch (error: unknown) {
+      failStructured(error, validated.format);
       return;
     }
 

--- a/src/commands/deep-research.ts
+++ b/src/commands/deep-research.ts
@@ -274,8 +274,8 @@ function buildDeepResearchJobArgv(v: ValidatedArgs): string[] {
   return argv;
 }
 
-function submitDetachedDeepResearchJob(v: ValidatedArgs): DetachedSubmitPayload {
-  const record = submitDetachedJob({
+async function submitDetachedDeepResearchJob(v: ValidatedArgs): Promise<DetachedSubmitPayload> {
+  const record = await submitDetachedJob({
     kind: 'deep-research',
     argv: buildDeepResearchJobArgv(v),
     prompt: v.mode.kind !== 'refresh' ? v.mode.prompt : undefined,
@@ -306,10 +306,10 @@ function dryRunMessage(v: ValidatedArgs): string {
   return `[dry-run] Would send Deep Research query (${parts.join(', ')})`;
 }
 
-function handleDryRunOrDetach(
+async function handleDryRunOrDetach(
   args: Record<string, unknown>,
   validated: ValidatedArgs,
-): boolean {
+): Promise<boolean> {
   if (args.dryRun === true) {
     progress(dryRunMessage(validated), false);
     return true;
@@ -317,7 +317,7 @@ function handleDryRunOrDetach(
   if (!validated.detach) {
     return false;
   }
-  const payload = submitDetachedDeepResearchJob(validated);
+  const payload = await submitDetachedDeepResearchJob(validated);
   writeDetachedSubmit(payload, validated.format);
   return true;
 }
@@ -444,7 +444,7 @@ export const deepResearchCommand = defineCommand({
       quiet, isVerbose, mode, format, stream, timeoutMs, timeoutSec, exportFormat, exportPath,
     } = v;
 
-    if (handleDryRunOrDetach(args, v)) {
+    if (await handleDryRunOrDetach(args, v)) {
       return;
     }
 

--- a/src/commands/deep-research.ts
+++ b/src/commands/deep-research.ts
@@ -8,7 +8,7 @@ import { FORMAT_ARG, GLOBAL_ARGS, STREAM_ARG, buildPrompt, formatTimeoutDisplay,
 import { type DetachedSubmitPayload, validateDetachedOptions, writeDetachedSubmit } from '../core/jobs/helpers.js';
 import { getJobFilePath } from '../core/jobs/store.js';
 import { submitDetachedJob } from '../core/jobs/submit.js';
-import { emitFinal, emitState, errorMessage, failValidation, json, progress, text, validateFormat, verbose } from '../core/output-handler.js';
+import { emitFinal, emitState, errorMessage, failStructured, failValidation, json, progress, text, validateFormat, verbose } from '../core/output-handler.js';
 import { withDriver } from '../core/with-driver.js';
 
 const DEFAULT_TIMEOUT_SEC = 0; // unlimited
@@ -444,7 +444,12 @@ export const deepResearchCommand = defineCommand({
       quiet, isVerbose, mode, format, stream, timeoutMs, timeoutSec, exportFormat, exportPath,
     } = v;
 
-    if (await handleDryRunOrDetach(args, v)) {
+    try {
+      if (await handleDryRunOrDetach(args, v)) {
+        return;
+      }
+    } catch (error: unknown) {
+      failStructured(error, v.format);
       return;
     }
 

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -305,7 +305,7 @@ export const waitCommand = defineCommand({
         timeoutMs,
         pollIntervalMs,
         args.quiet === true,
-        args.timeout === undefined,
+        timeoutSec === 0,
       );
       const result = readJobResult(job.jobId);
       const error = readJobError(job.jobId) ?? job.error;

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1,9 +1,12 @@
+import { existsSync, statSync } from 'node:fs';
+
 import { defineCommand } from 'citty';
 
 import { FORMAT_ARG, GLOBAL_ARGS, rejectUnknownFlags, toTimeoutMs } from '../core/cli-args.js';
 import { CavendishError, type StructuredErrorPayload } from '../core/errors.js';
 import { runJobRunnerOrExit } from '../core/jobs/runner.js';
-import { readJobError, readJobResult, readJob, listJobs } from '../core/jobs/store.js';
+import { getJobEventsPath, readJobError, readJobResult, readJob, listJobs } from '../core/jobs/store.js';
+import type { JobRecord } from '../core/jobs/types.js';
 import { runJobWorkerOrExit } from '../core/jobs/worker.js';
 import { fail, failStructured, jsonRaw, progress, text, validateFormat } from '../core/output-handler.js';
 
@@ -32,6 +35,10 @@ const RUN_WORKER_ARGS = {
 
 const RUN_RUNNER_ARGS = {};
 const WAIT_RUNNING_STALL_MS = 5 * 60 * 1000;
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
 
 function formatJobText(jobId: string, kind: string, status: string): string {
   return `${jobId}\t${kind}\t${status}`;
@@ -85,6 +92,41 @@ function readJobOrThrow(jobId: string): Exclude<ReturnType<typeof readJob>, unde
   }
 }
 
+function isWorkerPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    return isErrnoException(error) && error.code === 'EPERM';
+  }
+}
+
+function latestProgressMs(job: JobRecord): number | undefined {
+  const timestamps = [Date.parse(job.updatedAt)].filter((value) => Number.isFinite(value));
+  const eventsPath = getJobEventsPath(job.jobId);
+  if (existsSync(eventsPath)) {
+    timestamps.push(statSync(eventsPath).mtimeMs);
+  }
+  if (timestamps.length === 0) {
+    return undefined;
+  }
+  return Math.max(...timestamps);
+}
+
+function noProgressMsForRunningJob(job: JobRecord): number | undefined {
+  if (job.status !== 'running') {
+    return undefined;
+  }
+  if (job.workerPid !== undefined && isWorkerPidAlive(job.workerPid)) {
+    return undefined;
+  }
+  const progressMs = latestProgressMs(job);
+  if (progressMs === undefined) {
+    return undefined;
+  }
+  return Date.now() - progressMs;
+}
+
 async function waitForTerminalJob(
   jobId: string,
   timeoutMs: number,
@@ -99,9 +141,8 @@ async function waitForTerminalJob(
     if (job.status === 'completed' || job.status === 'failed' || job.status === 'timed_out' || job.status === 'cancelled') {
       return job;
     }
-    const updatedAtMs = Date.parse(job.updatedAt);
-    const noProgressMs = Date.now() - updatedAtMs;
-    if (detectNoProgress && job.status === 'running' && Number.isFinite(updatedAtMs) && noProgressMs >= WAIT_RUNNING_STALL_MS) {
+    const noProgressMs = noProgressMsForRunningJob(job);
+    if (detectNoProgress && noProgressMs !== undefined && noProgressMs >= WAIT_RUNNING_STALL_MS) {
       const message = `Detached job ${job.jobId} has made no progress for ${String(Math.round(noProgressMs / 1000))}s.`;
       if (pollIntervalMs !== undefined) {
         progress(message, quiet);

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -1,11 +1,10 @@
-import { existsSync, statSync } from 'node:fs';
-
 import { defineCommand } from 'citty';
 
 import { FORMAT_ARG, GLOBAL_ARGS, rejectUnknownFlags, toTimeoutMs } from '../core/cli-args.js';
 import { CavendishError, type StructuredErrorPayload } from '../core/errors.js';
+import { isWorkerPidAlive, latestJobProgressMs } from '../core/jobs/pid-utils.js';
 import { runJobRunnerOrExit } from '../core/jobs/runner.js';
-import { getJobEventsPath, readJobError, readJobResult, readJob, listJobs } from '../core/jobs/store.js';
+import { readJobError, readJobResult, readJob, listJobs } from '../core/jobs/store.js';
 import type { JobRecord } from '../core/jobs/types.js';
 import { runJobWorkerOrExit } from '../core/jobs/worker.js';
 import { fail, failStructured, jsonRaw, progress, text, validateFormat } from '../core/output-handler.js';
@@ -35,10 +34,6 @@ const RUN_WORKER_ARGS = {
 
 const RUN_RUNNER_ARGS = {};
 const WAIT_RUNNING_STALL_MS = 5 * 60 * 1000;
-
-function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && 'code' in error;
-}
 
 function formatJobText(jobId: string, kind: string, status: string): string {
   return `${jobId}\t${kind}\t${status}`;
@@ -92,27 +87,6 @@ function readJobOrThrow(jobId: string): Exclude<ReturnType<typeof readJob>, unde
   }
 }
 
-function isWorkerPidAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error: unknown) {
-    return isErrnoException(error) && error.code === 'EPERM';
-  }
-}
-
-function latestProgressMs(job: JobRecord): number | undefined {
-  const timestamps = [Date.parse(job.updatedAt)].filter((value) => Number.isFinite(value));
-  const eventsPath = getJobEventsPath(job.jobId);
-  if (existsSync(eventsPath)) {
-    timestamps.push(statSync(eventsPath).mtimeMs);
-  }
-  if (timestamps.length === 0) {
-    return undefined;
-  }
-  return Math.max(...timestamps);
-}
-
 function noProgressMsForRunningJob(job: JobRecord): number | undefined {
   if (job.status !== 'running') {
     return undefined;
@@ -120,7 +94,7 @@ function noProgressMsForRunningJob(job: JobRecord): number | undefined {
   if (job.workerPid !== undefined && isWorkerPidAlive(job.workerPid)) {
     return undefined;
   }
-  const progressMs = latestProgressMs(job);
+  const progressMs = latestJobProgressMs(job);
   if (progressMs === undefined) {
     return undefined;
   }

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -31,6 +31,7 @@ const RUN_WORKER_ARGS = {
 };
 
 const RUN_RUNNER_ARGS = {};
+const WAIT_RUNNING_STALL_MS = 5 * 60 * 1000;
 
 function formatJobText(jobId: string, kind: string, status: string): string {
   return `${jobId}\t${kind}\t${status}`;
@@ -89,6 +90,7 @@ async function waitForTerminalJob(
   timeoutMs: number,
   pollIntervalMs: number | undefined,
   quiet: boolean,
+  detectNoProgress: boolean,
 ): Promise<Exclude<ReturnType<typeof readJob>, undefined>> {
   const deadline = Date.now() + timeoutMs;
   let nextProgressAt = pollIntervalMs !== undefined ? Date.now() : undefined;
@@ -96,6 +98,19 @@ async function waitForTerminalJob(
     const job = readJobOrThrow(jobId);
     if (job.status === 'completed' || job.status === 'failed' || job.status === 'timed_out' || job.status === 'cancelled') {
       return job;
+    }
+    const updatedAtMs = Date.parse(job.updatedAt);
+    const noProgressMs = Date.now() - updatedAtMs;
+    if (detectNoProgress && job.status === 'running' && Number.isFinite(updatedAtMs) && noProgressMs >= WAIT_RUNNING_STALL_MS) {
+      const message = `Detached job ${job.jobId} has made no progress for ${String(Math.round(noProgressMs / 1000))}s.`;
+      if (pollIntervalMs !== undefined) {
+        progress(message, quiet);
+      }
+      throw new CavendishError(
+        message,
+        'job_no_progress',
+        `Inspect job ${job.jobId} with \`cavendish jobs read ${job.jobId}\`, then restart Chrome and retry if needed.`,
+      );
     }
     if (pollIntervalMs !== undefined && nextProgressAt !== undefined && Date.now() >= nextProgressAt) {
       progress(
@@ -244,7 +259,13 @@ export const waitCommand = defineCommand({
     }
     const timeoutMs = toTimeoutMs(timeoutSec);
     try {
-      const job = await waitForTerminalJob(args.jobId, timeoutMs, pollIntervalMs, args.quiet === true);
+      const job = await waitForTerminalJob(
+        args.jobId,
+        timeoutMs,
+        pollIntervalMs,
+        args.quiet === true,
+        args.timeout === undefined,
+      );
       const result = readJobResult(job.jobId);
       const error = readJobError(job.jobId) ?? job.error;
       if (job.status === 'failed' || job.status === 'cancelled' || (job.status === 'timed_out' && result === undefined)) {

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -213,7 +213,7 @@ export async function checkGoogleDrive(page: Page): Promise<DoctorCheck> {
       };
     }
 
-    await plusBtn.first().click();
+    await plusBtn.click();
     try {
       await page.locator(SELECTORS.MENU_ITEM).first().waitFor({
         state: 'visible',
@@ -237,8 +237,9 @@ export async function checkGoogleDrive(page: Page): Promise<DoctorCheck> {
   } catch (error: unknown) {
     return {
       name: 'gdrive_picker',
-      status: 'skip',
-      detail: `Check failed: ${errorMessage(error)}`,
+      status: 'fail',
+      detail: `Failed to verify Google Drive menu: ${errorMessage(error)}`,
+      action: 'Verify the composer + menu is visible and check the Chrome console for errors',
     };
   }
 }

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -220,10 +220,10 @@ export async function checkGoogleDrive(page: Page): Promise<DoctorCheck> {
         timeout: DOCTOR_CHECK_TIMEOUT_MS,
       });
       const labels = MENU_LABELS.ADD_FROM_GOOGLE_DRIVE;
-      const counts = await Promise.all(
-        labels.map((label) => page.locator(SELECTORS.MENU_ITEM).filter({ hasText: label }).count()),
+      const visibleMatches = await Promise.all(
+        labels.map((label) => page.locator(SELECTORS.MENU_ITEM).filter({ hasText: label }).first().isVisible()),
       );
-      if (counts.some((count) => count > 0)) {
+      if (visibleMatches.some((visible) => visible)) {
         return { name: 'gdrive_picker', status: 'pass', detail: 'Google Drive menu entry found' };
       }
       return {

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -213,7 +213,7 @@ export async function checkGoogleDrive(page: Page): Promise<DoctorCheck> {
       };
     }
 
-    await plusBtn.click();
+    await plusBtn.first().click();
     try {
       await page.locator(SELECTORS.MENU_ITEM).first().waitFor({
         state: 'visible',

--- a/src/core/doctor.ts
+++ b/src/core/doctor.ts
@@ -10,7 +10,7 @@ import { existsSync } from 'node:fs';
 
 import type { Page } from 'playwright-core';
 
-import { CHATGPT_BASE_URL, SELECTORS } from '../constants/selectors.js';
+import { CHATGPT_BASE_URL, MENU_LABELS, SELECTORS } from '../constants/selectors.js';
 
 import { BrowserManager, CDP_ENDPOINT_FILE, CHROME_PROFILE_DIR, resolveCdpBaseUrl } from './browser-manager.js';
 import { errorMessage, progress } from './output-handler.js';
@@ -201,7 +201,7 @@ async function checkModelPicker(page: Page): Promise<DoctorCheck> {
 /**
  * Check if the Google Drive menu item is accessible via the composer + menu.
  */
-async function checkGoogleDrive(page: Page): Promise<DoctorCheck> {
+export async function checkGoogleDrive(page: Page): Promise<DoctorCheck> {
   try {
     const plusBtn = page.locator(SELECTORS.COMPOSER_PLUS_BUTTON);
     const plusCount = await plusBtn.count();
@@ -213,10 +213,27 @@ async function checkGoogleDrive(page: Page): Promise<DoctorCheck> {
       };
     }
 
-    // Google Drive is a menu item inside the + menu, but opening the menu
-    // to verify the Drive entry would be invasive (clicks, side-effects).
-    // We only verify the entry point (+ button) as a non-intrusive proxy.
-    return { name: 'gdrive_picker', status: 'skip', detail: 'Composer + button found but Drive menu entry not verified' };
+    await plusBtn.first().click();
+    try {
+      await page.locator(SELECTORS.MENU_ITEM).first().waitFor({
+        state: 'visible',
+        timeout: DOCTOR_CHECK_TIMEOUT_MS,
+      });
+      const labels = MENU_LABELS.ADD_FROM_GOOGLE_DRIVE;
+      const counts = await Promise.all(
+        labels.map((label) => page.locator(SELECTORS.MENU_ITEM).filter({ hasText: label }).count()),
+      );
+      if (counts.some((count) => count > 0)) {
+        return { name: 'gdrive_picker', status: 'pass', detail: 'Google Drive menu entry found' };
+      }
+      return {
+        name: 'gdrive_picker',
+        status: 'skip',
+        detail: 'Composer + menu opened but Google Drive menu entry was not found',
+      };
+    } finally {
+      await page.keyboard.press('Escape');
+    }
   } catch (error: unknown) {
     return {
       name: 'gdrive_picker',
@@ -293,13 +310,13 @@ async function runPlaywrightChecks(page: Page): Promise<DoctorCheck[]> {
     ];
   }
 
-  // Run interactive checks in parallel
-  const [prompt, model, gdrive, github] = await Promise.all([
+  // Run passive checks in parallel, then the menu-opening check by itself.
+  const [prompt, model, github] = await Promise.all([
     checkPromptTextarea(page),
     checkModelPicker(page),
-    checkGoogleDrive(page),
     checkGitHub(page),
   ]);
+  const gdrive = await checkGoogleDrive(page);
 
   return [cloudflare, auth, prompt, model, gdrive, github];
 }

--- a/src/core/driver/response-handler.ts
+++ b/src/core/driver/response-handler.ts
@@ -7,7 +7,7 @@ import type { Page } from 'playwright-core';
 
 import { SELECTORS } from '../../constants/selectors.js';
 import type { WaitForResponseOptions, WaitForResponseResult } from '../chatgpt-types.js';
-import { CavendishError } from '../errors.js';
+import { CavendishError, classifyError } from '../errors.js';
 import { errorMessage, progress } from '../output-handler.js';
 
 import { DEFAULT_TIMEOUT_MS, delay, POLL_INTERVAL_MS } from './helpers.js';
@@ -81,6 +81,13 @@ function resolveStallTimeout(timeout: number): number {
     timeout,
     Math.max(MIN_STALL_TIMEOUT_MS, Math.floor(timeout / 4)),
   );
+}
+
+function rethrowBrowserDisconnect(error: unknown): void {
+  const classified = classifyError(error);
+  if (classified.category === 'browser_disconnected' || classified.category === 'cdp_unavailable') {
+    throw classified;
+  }
 }
 
 async function monitorResponse(
@@ -158,6 +165,7 @@ async function getResponseSnapshot(
   try {
     stopButtonVisible = await page.locator(SELECTORS.STOP_BUTTON).isVisible();
   } catch (error: unknown) {
+    rethrowBrowserDisconnect(error);
     throw new CavendishError(
       `Failed to inspect stop button visibility (selector: ${SELECTORS.STOP_BUTTON}): ${errorMessage(error)}`,
       'selector_miss',
@@ -212,6 +220,7 @@ async function getResponseSnapshot(
       },
     );
   } catch (error: unknown) {
+    rethrowBrowserDisconnect(error);
     throw new CavendishError(
       `Failed to read response snapshot (selectors: ${SELECTORS.ASSISTANT_MESSAGE}, ${SELECTORS.COPY_BUTTON}, ${SELECTORS.THINKING_INDICATOR}, offset: ${String(previousCount)}): ${errorMessage(error)}`,
       'selector_miss',

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -13,7 +13,10 @@ export type ErrorCategory =
   | 'chrome_close_failed'
   | 'auth_expired'
   | 'cloudflare_blocked'
+  | 'browser_disconnected'
   | 'selector_miss'
+  | 'job_no_progress'
+  | 'runner_killed'
   | 'timeout'
   | 'unknown';
 
@@ -28,6 +31,9 @@ export const EXIT_CODES: Readonly<Record<ErrorCategory, number>> = {
   timeout: 7,
   chrome_launch_failed: 8,
   chrome_close_failed: 9,
+  browser_disconnected: 10,
+  runner_killed: 11,
+  job_no_progress: 12,
 };
 
 /** Suggested user actions per error category. */
@@ -44,8 +50,14 @@ const DEFAULT_ACTIONS: Readonly<Record<ErrorCategory, string>> = {
     'Open Chrome and log in to ChatGPT, then retry.',
   cloudflare_blocked:
     'Open the ChatGPT tab in Chrome and solve the Cloudflare challenge manually.',
+  browser_disconnected:
+    'Chrome was closed or crashed. Restart Chrome and re-run the command.',
   selector_miss:
     'ChatGPT UI may have changed. Run "cavendish status" and check for updates.',
+  job_no_progress:
+    'Inspect the detached job events, then restart Chrome and retry the job if no worker is active.',
+  runner_killed:
+    'Restart the detached job; the runner process was interrupted before it could finish.',
   timeout:
     'Increase --timeout or check if ChatGPT is responding in the browser.',
   unknown:
@@ -104,6 +116,17 @@ export function classifyError(error: unknown): CavendishError {
 
   const message = error instanceof Error ? error.message : String(error);
   const lower = message.toLowerCase();
+
+  // Browser/CDP target closure must be checked before selector classifiers:
+  // Playwright often includes "waiting for locator" in the same message.
+  if (
+    lower.includes('target page, context or browser has been closed') ||
+    lower.includes('target closed') ||
+    lower.includes('browser has been closed') ||
+    lower.includes('page has been closed')
+  ) {
+    return new CavendishError(message, 'browser_disconnected');
+  }
 
   // CDP / Chrome connection errors
   if (

--- a/src/core/jobs/pid-utils.ts
+++ b/src/core/jobs/pid-utils.ts
@@ -1,0 +1,30 @@
+import { existsSync, statSync } from 'node:fs';
+
+import type { JobRecord } from './types.js';
+
+export function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+export function isWorkerPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    if (!isErrnoException(error)) {
+      return true;
+    }
+    return error.code !== 'ESRCH';
+  }
+}
+
+export function latestJobProgressMs(job: JobRecord): number | undefined {
+  const timestamps = [Date.parse(job.updatedAt)].filter((value) => Number.isFinite(value));
+  if (typeof job.eventsPath === 'string' && existsSync(job.eventsPath)) {
+    timestamps.push(statSync(job.eventsPath).mtimeMs);
+  }
+  if (timestamps.length === 0) {
+    return undefined;
+  }
+  return Math.max(...timestamps);
+}

--- a/src/core/jobs/runner.ts
+++ b/src/core/jobs/runner.ts
@@ -3,13 +3,14 @@ import { join } from 'node:path';
 
 import { CAVENDISH_DIR } from '../browser-manager.js';
 import { progress } from '../output-handler.js';
+import { registerCleanup } from '../shutdown.js';
 
 import { readNextQueuedJob } from './store.js';
-import { markUnexpectedJobFailure, runJobWorker } from './worker.js';
+import { markJobRunnerKilled, markUnexpectedJobFailure, runJobWorker } from './worker.js';
 
 const RUNNER_LOCK_FILE = join(CAVENDISH_DIR, 'jobs-runner.lock');
-const RUNNER_LOCK_MAX_ATTEMPTS = 3;
-const RUNNER_LOCK_RETRY_MS = 200;
+const RUNNER_LOCK_MAX_ATTEMPTS = 11;
+const RUNNER_LOCK_RETRY_MS = 500;
 const JOB_RETRY_DELAY_MS = 2_000;
 let runnerPromise: Promise<void> | null = null;
 
@@ -192,6 +193,9 @@ async function runJobRunnerOnce(): Promise<void> {
       if (nextJob === undefined) {
         return;
       }
+      const unregisterKilledCleanup = registerCleanup(() => {
+        markJobRunnerKilled(nextJob.jobId);
+      });
       try {
         const result = await runJobWorker(nextJob.jobId);
         if (result.outcome === 'retry') {
@@ -206,6 +210,8 @@ async function runJobRunnerOnce(): Promise<void> {
       } catch (error: unknown) {
         markUnexpectedJobFailure(nextJob.jobId, error, 'Detached runner job failed');
         continue;
+      } finally {
+        unregisterKilledCleanup();
       }
     }
   } finally {

--- a/src/core/jobs/runner.ts
+++ b/src/core/jobs/runner.ts
@@ -5,6 +5,7 @@ import { CAVENDISH_DIR } from '../browser-manager.js';
 import { progress } from '../output-handler.js';
 import { registerCleanup } from '../shutdown.js';
 
+import { isErrnoException, isWorkerPidAlive } from './pid-utils.js';
 import { readNextQueuedJob } from './store.js';
 import { markJobRunnerKilled, markUnexpectedJobFailure, runJobWorker } from './worker.js';
 
@@ -13,19 +14,6 @@ const RUNNER_LOCK_MAX_ATTEMPTS = 11;
 const RUNNER_LOCK_RETRY_MS = 500;
 const JOB_RETRY_DELAY_MS = 2_000;
 let runnerPromise: Promise<void> | null = null;
-
-function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && 'code' in error;
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error: unknown) {
-    return isErrnoException(error) && error.code === 'EPERM';
-  }
-}
 
 function readLockPidFromPath(path: string): number | null {
   try {
@@ -119,7 +107,7 @@ function tryAcquireRunnerLock(): boolean {
   if (existingPid === process.pid) {
     return true;
   }
-  if (existingPid !== null && isProcessAlive(existingPid)) {
+  if (existingPid !== null && isWorkerPidAlive(existingPid)) {
     return false;
   }
   if (tryClaimStaleLock(existingPid)) {

--- a/src/core/jobs/store.ts
+++ b/src/core/jobs/store.ts
@@ -3,7 +3,7 @@ import { appendFileSync, chmodSync, existsSync, mkdirSync, readdirSync, readFile
 import { dirname, join } from 'node:path';
 
 import { CAVENDISH_DIR } from '../browser-manager.js';
-import type { StructuredErrorPayload } from '../errors.js';
+import { EXIT_CODES, type StructuredErrorPayload } from '../errors.js';
 
 import { notifyJobCompletion } from './notifier.js';
 import { isWorkerPidAlive, latestJobProgressMs } from './pid-utils.js';
@@ -258,7 +258,7 @@ function recoverStaleRunningJob(job: JobRecord, reason: string): JobRecord {
       error: true,
       category: 'job_no_progress',
       message: `Detached job ${job.jobId} did not make progress: ${reason}.`,
-      exitCode: 12,
+      exitCode: EXIT_CODES.job_no_progress,
       action: 'Inspect the job events and submit the job again if needed.',
     };
     writeJobError(job.jobId, error);

--- a/src/core/jobs/store.ts
+++ b/src/core/jobs/store.ts
@@ -6,6 +6,7 @@ import { CAVENDISH_DIR } from '../browser-manager.js';
 import type { StructuredErrorPayload } from '../errors.js';
 
 import { notifyJobCompletion } from './notifier.js';
+import { isWorkerPidAlive, latestJobProgressMs } from './pid-utils.js';
 import type { DetachedJobRequest, JobKind, JobRecord, JobResultRecord, JobStatus } from './types.js';
 
 const JOBS_DIR = join(CAVENDISH_DIR, 'jobs');
@@ -31,10 +32,6 @@ function assertValidJobId(jobId: string): void {
   if (!UUID_PATTERN.test(jobId)) {
     throw new Error(`Invalid job ID: ${jobId}`);
   }
-}
-
-function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && 'code' in error;
 }
 
 function writeJsonAtomic(path: string, data: unknown): void {
@@ -238,33 +235,18 @@ export function listJobs(): JobRecord[] {
     .sort((a, b) => b.submittedAt.localeCompare(a.submittedAt));
 }
 
-function isWorkerPidDead(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return false;
-  } catch (error: unknown) {
-    if (isErrnoException(error) && error.code === 'EPERM') {
-      return false;
-    }
-    if (isErrnoException(error) && error.code === 'ESRCH') {
-      return true;
-    }
-    return true;
-  }
-}
-
 function staleRunningReason(job: JobRecord, nowMs: number): string | undefined {
   if (job.status !== 'running') {
     return undefined;
   }
   if (job.workerPid !== undefined) {
-    return isWorkerPidDead(job.workerPid)
+    return !isWorkerPidAlive(job.workerPid)
       ? `worker process ${String(job.workerPid)} is no longer running`
       : undefined;
   }
-  const updatedAtMs = Date.parse(job.updatedAt);
-  if (Number.isFinite(updatedAtMs) && nowMs - updatedAtMs >= STALE_RUNNING_JOB_MS) {
-    return `no progress for ${String(Math.round((nowMs - updatedAtMs) / 1000))}s`;
+  const progressMs = latestJobProgressMs(job);
+  if (progressMs !== undefined && nowMs - progressMs >= STALE_RUNNING_JOB_MS) {
+    return `no progress for ${String(Math.round((nowMs - progressMs) / 1000))}s`;
   }
   return undefined;
 }

--- a/src/core/jobs/store.ts
+++ b/src/core/jobs/store.ts
@@ -256,8 +256,10 @@ function staleRunningReason(job: JobRecord, nowMs: number): string | undefined {
   if (job.status !== 'running') {
     return undefined;
   }
-  if (job.workerPid !== undefined && isWorkerPidDead(job.workerPid)) {
-    return `worker process ${String(job.workerPid)} is no longer running`;
+  if (job.workerPid !== undefined) {
+    return isWorkerPidDead(job.workerPid)
+      ? `worker process ${String(job.workerPid)} is no longer running`
+      : undefined;
   }
   const updatedAtMs = Date.parse(job.updatedAt);
   if (Number.isFinite(updatedAtMs) && nowMs - updatedAtMs >= STALE_RUNNING_JOB_MS) {

--- a/src/core/jobs/store.ts
+++ b/src/core/jobs/store.ts
@@ -18,6 +18,8 @@ const FILE_MODE = 0o600;
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const JOB_KINDS: readonly JobKind[] = ['ask', 'deep-research'];
 const JOB_STATUSES: readonly JobStatus[] = ['queued', 'running', 'completed', 'failed', 'timed_out', 'cancelled'];
+const STALE_RUNNING_JOB_MS = 30 * 60 * 1000;
+const STALE_RUNNING_JOB_MAX_RETRIES = 3;
 
 function ensureDir(path: string): void {
   mkdirSync(path, { recursive: true, mode: DIR_MODE });
@@ -28,6 +30,10 @@ function assertValidJobId(jobId: string): void {
   if (!UUID_PATTERN.test(jobId)) {
     throw new Error(`Invalid job ID: ${jobId}`);
   }
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
 }
 
 function writeJsonAtomic(path: string, data: unknown): void {
@@ -196,6 +202,7 @@ function assertValidJobRecordShape(record: unknown, label: string): asserts reco
   assertOptionalStringField(candidate.lastRetryError, 'lastRetryError', label);
   assertOptionalBooleanField(candidate.partial, 'partial', label);
   assertOptionalNumberField(candidate.exitCode, 'exitCode', label);
+  assertOptionalNumberField(candidate.workerPid, 'workerPid', label);
 }
 
 export function readJob(jobId: string): JobRecord | undefined {
@@ -230,12 +237,79 @@ export function listJobs(): JobRecord[] {
     .sort((a, b) => b.submittedAt.localeCompare(a.submittedAt));
 }
 
+function isWorkerPidDead(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return false;
+  } catch (error: unknown) {
+    if (isErrnoException(error) && error.code === 'EPERM') {
+      return false;
+    }
+    if (isErrnoException(error) && error.code === 'ESRCH') {
+      return true;
+    }
+    return true;
+  }
+}
+
+function staleRunningReason(job: JobRecord, nowMs: number): string | undefined {
+  if (job.status !== 'running') {
+    return undefined;
+  }
+  if (job.workerPid !== undefined && isWorkerPidDead(job.workerPid)) {
+    return `worker process ${String(job.workerPid)} is no longer running`;
+  }
+  const updatedAtMs = Date.parse(job.updatedAt);
+  if (Number.isFinite(updatedAtMs) && nowMs - updatedAtMs >= STALE_RUNNING_JOB_MS) {
+    return `no progress for ${String(Math.round((nowMs - updatedAtMs) / 1000))}s`;
+  }
+  return undefined;
+}
+
+function recoverStaleRunningJob(job: JobRecord, reason: string): JobRecord {
+  const retryCount = Number.isFinite(job.retryCount) ? job.retryCount : 0;
+  if (retryCount >= STALE_RUNNING_JOB_MAX_RETRIES) {
+    const error: StructuredErrorPayload = {
+      error: true,
+      category: 'job_no_progress',
+      message: `Detached job ${job.jobId} did not make progress: ${reason}.`,
+      exitCode: 12,
+      action: 'Inspect the job events and submit the job again if needed.',
+    };
+    writeJobError(job.jobId, error);
+    return updateJob(job.jobId, {
+      status: 'failed',
+      completedAt: new Date().toISOString(),
+      error,
+      exitCode: error.exitCode,
+      workerPid: undefined,
+      lastRetryError: reason,
+    });
+  }
+  return updateJob(job.jobId, {
+    status: 'queued',
+    startedAt: undefined,
+    workerPid: undefined,
+    retryCount: retryCount + 1,
+    lastRetriedAt: new Date().toISOString(),
+    lastRetryError: `Recovered stale running job: ${reason}`,
+  });
+}
+
 export function readNextQueuedJob(): JobRecord | undefined {
   const jobs = listJobs();
+  const nowMs = Date.now();
   for (let index = jobs.length - 1; index >= 0; index -= 1) {
     const job = jobs[index];
     if (job.status === 'queued') {
       return job;
+    }
+    const staleReason = staleRunningReason(job, nowMs);
+    if (staleReason !== undefined) {
+      const recovered = recoverStaleRunningJob(job, staleReason);
+      if (recovered.status === 'queued') {
+        return recovered;
+      }
     }
   }
   return undefined;

--- a/src/core/jobs/store.ts
+++ b/src/core/jobs/store.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { CAVENDISH_DIR } from '../browser-manager.js';
 import type { StructuredErrorPayload } from '../errors.js';
 
+import { notifyJobCompletion } from './notifier.js';
 import type { DetachedJobRequest, JobKind, JobRecord, JobResultRecord, JobStatus } from './types.js';
 
 const JOBS_DIR = join(CAVENDISH_DIR, 'jobs');
@@ -279,7 +280,7 @@ function recoverStaleRunningJob(job: JobRecord, reason: string): JobRecord {
       action: 'Inspect the job events and submit the job again if needed.',
     };
     writeJobError(job.jobId, error);
-    return updateJob(job.jobId, {
+    const record = updateJob(job.jobId, {
       status: 'failed',
       completedAt: new Date().toISOString(),
       error,
@@ -287,6 +288,14 @@ function recoverStaleRunningJob(job: JobRecord, reason: string): JobRecord {
       workerPid: undefined,
       lastRetryError: reason,
     });
+    appendJobEvent(job.jobId, JSON.stringify({
+      type: 'state',
+      state: 'job-failed',
+      content: '',
+      timestamp: new Date().toISOString(),
+    }));
+    notifyJobCompletion(record);
+    return record;
   }
   return updateJob(job.jobId, {
     status: 'queued',

--- a/src/core/jobs/submit.ts
+++ b/src/core/jobs/submit.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 
 import { CavendishError } from '../errors.js';
 
-import { createJob, updateJob, writeJobError } from './store.js';
+import { createJob, readJob, updateJob, writeJobError } from './store.js';
 import type { DetachedJobRequest, JobRecord } from './types.js';
 
 const STARTUP_OBSERVE_MS = 500;
@@ -79,5 +79,5 @@ export async function submitDetachedJob(request: DetachedJobRequest): Promise<Jo
     markLaunchFailed(error);
     throw error;
   }
-  return record;
+  return readJob(record.jobId) ?? record;
 }

--- a/src/core/jobs/submit.ts
+++ b/src/core/jobs/submit.ts
@@ -1,9 +1,11 @@
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 
 import { CavendishError } from '../errors.js';
 
 import { createJob, updateJob, writeJobError } from './store.js';
 import type { DetachedJobRequest, JobRecord } from './types.js';
+
+const STARTUP_OBSERVE_MS = 500;
 
 function resolveCliEntrypoint(): string {
   const entry = process.argv[1];
@@ -17,7 +19,32 @@ function resolveCliEntrypoint(): string {
   return entry;
 }
 
-export function submitDetachedJob(request: DetachedJobRequest): JobRecord {
+function waitForRunnerSpawn(child: ChildProcess): Promise<void> {
+  return new Promise((resolve, reject) => {
+    child.once('spawn', resolve);
+    child.once('error', reject);
+  });
+}
+
+function observeEarlyRunnerExit(
+  child: ChildProcess,
+  markLaunchFailed: (error: unknown) => void,
+): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, STARTUP_OBSERVE_MS);
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      if ((code ?? 0) !== 0 || signal !== null) {
+        markLaunchFailed(
+          new Error(`Detached runner exited during startup (code: ${String(code)}, signal: ${String(signal)})`),
+        );
+      }
+      resolve();
+    });
+  });
+}
+
+export async function submitDetachedJob(request: DetachedJobRequest): Promise<JobRecord> {
   const record = createJob(request);
   const markLaunchFailed = (error: unknown): void => {
     const payload = {
@@ -44,9 +71,9 @@ export function submitDetachedJob(request: DetachedJobRequest): JobRecord {
         stdio: 'ignore',
       },
     );
-    child.once('error', (error: unknown): void => {
-      markLaunchFailed(error);
-    });
+    const earlyExitPromise = observeEarlyRunnerExit(child, markLaunchFailed);
+    await waitForRunnerSpawn(child);
+    await earlyExitPromise;
     child.unref();
   } catch (error: unknown) {
     markLaunchFailed(error);

--- a/src/core/jobs/submit.ts
+++ b/src/core/jobs/submit.ts
@@ -21,8 +21,20 @@ function resolveCliEntrypoint(): string {
 
 function waitForRunnerSpawn(child: ChildProcess): Promise<void> {
   return new Promise((resolve, reject) => {
-    child.once('spawn', resolve);
-    child.once('error', reject);
+    const cleanup = (): void => {
+      child.off('spawn', onSpawn);
+      child.off('error', onError);
+    };
+    const onSpawn = (): void => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error): void => {
+      cleanup();
+      reject(error);
+    };
+    child.once('spawn', onSpawn);
+    child.once('error', onError);
   });
 }
 
@@ -31,8 +43,7 @@ function observeEarlyRunnerExit(
   markLaunchFailed: (error: unknown) => void,
 ): Promise<void> {
   return new Promise((resolve) => {
-    const timer = setTimeout(resolve, STARTUP_OBSERVE_MS);
-    child.once('exit', (code, signal) => {
+    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
       clearTimeout(timer);
       if ((code ?? 0) !== 0 || signal !== null) {
         markLaunchFailed(
@@ -40,7 +51,12 @@ function observeEarlyRunnerExit(
         );
       }
       resolve();
-    });
+    };
+    const timer = setTimeout(() => {
+      child.off('exit', onExit);
+      resolve();
+    }, STARTUP_OBSERVE_MS);
+    child.once('exit', onExit);
   });
 }
 

--- a/src/core/jobs/types.ts
+++ b/src/core/jobs/types.ts
@@ -33,6 +33,7 @@ export interface JobRecord {
   partial?: boolean;
   exitCode?: number;
   retryCount: number;
+  workerPid?: number;
   lastRetriedAt?: string;
   lastRetryError?: string;
   resultPath: string;

--- a/src/core/jobs/worker.ts
+++ b/src/core/jobs/worker.ts
@@ -21,6 +21,16 @@ function normalizeFailureExitCode(exitCode: number | undefined): number {
   return typeof exitCode === 'number' && exitCode !== 0 ? exitCode : 1;
 }
 
+function normalizeStructuredExitCode(
+  exitCode: number,
+  structuredError: StructuredErrorPayload | undefined,
+): number {
+  if (structuredError === undefined) {
+    return normalizeFailureExitCode(exitCode);
+  }
+  return Math.max(exitCode, normalizeFailureExitCode(structuredError.exitCode));
+}
+
 function resolveCliEntrypoint(): string {
   const entry = process.argv[1];
   if (typeof entry !== 'string' || entry.length === 0) {
@@ -209,7 +219,7 @@ export async function runJobWorker(jobId: string): Promise<JobRunResult> {
   appendJobState(jobId, 'job-running');
 
   const { exitCode, finalEvent, structuredError, stderrLines } = await runWorkerAttempt(jobId, record);
-  const normalizedExitCode = structuredError === undefined ? normalizeFailureExitCode(exitCode) : exitCode;
+  const normalizedExitCode = normalizeStructuredExitCode(exitCode, structuredError);
 
   if (finalEvent !== undefined) {
     writeJobResult(jobId, {

--- a/src/core/jobs/worker.ts
+++ b/src/core/jobs/worker.ts
@@ -11,10 +11,60 @@ import type { JobRecord, JobStatus } from './types.js';
 
 type JobRunOutcome = 'completed' | 'failed' | 'timed_out' | 'retry';
 
+const STDERR_LINE_LIMIT = 100;
+const STDERR_BYTES_LIMIT = 16 * 1024;
+const STDERR_TRUNCATION_MARKER = '[stderr truncated: keeping the most recent output]';
+
 interface JobRunResult {
   outcome: JobRunOutcome;
   record?: JobRecord;
   error?: StructuredErrorPayload;
+}
+
+interface StderrCapture {
+  lines: string[];
+  bytes: number;
+  truncated: boolean;
+}
+
+function createStderrCapture(): StderrCapture {
+  return {
+    lines: [],
+    bytes: 0,
+    truncated: false,
+  };
+}
+
+function stderrLineBytes(line: string): number {
+  return Buffer.byteLength(line, 'utf8') + 1;
+}
+
+function trimStderrCapture(capture: StderrCapture): void {
+  while (capture.lines.length > 0) {
+    const lineLimit = capture.truncated ? STDERR_LINE_LIMIT - 1 : STDERR_LINE_LIMIT;
+    if (capture.lines.length <= lineLimit && capture.bytes <= STDERR_BYTES_LIMIT) {
+      return;
+    }
+    const removed = capture.lines.shift();
+    if (removed === undefined) {
+      return;
+    }
+    capture.bytes -= stderrLineBytes(removed);
+    capture.truncated = true;
+  }
+}
+
+function appendCapturedStderr(capture: StderrCapture, line: string): void {
+  capture.lines.push(line);
+  capture.bytes += stderrLineBytes(line);
+  trimStderrCapture(capture);
+}
+
+function formatCapturedStderr(capture: StderrCapture): string[] {
+  if (!capture.truncated) {
+    return [...capture.lines];
+  }
+  return [STDERR_TRUNCATION_MARKER, ...capture.lines];
 }
 
 function normalizeFailureExitCode(exitCode: number | undefined): number {
@@ -153,7 +203,7 @@ async function runWorkerAttempt(jobId: string, job: JobRecord): Promise<{
   let finalEvent: NdjsonEvent | undefined;
   let structuredError: StructuredErrorPayload | undefined;
   let stdinError: StructuredErrorPayload | undefined;
-  const stderrLines: string[] = [];
+  const stderrCapture = createStderrCapture();
 
   child.stdin.on('error', (error: unknown) => {
     stdinError = makeStdinErrorPayload(error);
@@ -183,7 +233,7 @@ async function runWorkerAttempt(jobId: string, job: JobRecord): Promise<{
       structuredError = parsed;
       return;
     }
-    stderrLines.push(line);
+    appendCapturedStderr(stderrCapture, line);
     appendStderrEvent(jobId, line);
   });
 
@@ -201,7 +251,7 @@ async function runWorkerAttempt(jobId: string, job: JobRecord): Promise<{
     exitCode,
     finalEvent,
     structuredError: structuredError ?? stdinError,
-    stderrLines,
+    stderrLines: formatCapturedStderr(stderrCapture),
   };
 }
 

--- a/src/core/jobs/worker.ts
+++ b/src/core/jobs/worker.ts
@@ -45,19 +45,26 @@ function parseEvent(line: string): NdjsonEvent | undefined {
       return undefined;
     }
     return parsed as unknown as NdjsonEvent;
-  } catch {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`[cavendish:jobs] failed to parse worker event: ${message}\n`);
     return undefined;
   }
 }
 
 function parseStructuredError(line: string): StructuredErrorPayload | undefined {
+  if (!line.trimStart().startsWith('{')) {
+    return undefined;
+  }
   try {
     const parsed = JSON.parse(line) as Record<string, unknown>;
     if (parsed.error === true && typeof parsed.message === 'string' && typeof parsed.category === 'string') {
       return parsed as unknown as StructuredErrorPayload;
     }
     return undefined;
-  } catch {
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`[cavendish:jobs] failed to parse worker stderr as JSON: ${message}\n`);
     return undefined;
   }
 }
@@ -89,10 +96,36 @@ function terminalStatusFromError(error: StructuredErrorPayload): Extract<JobStat
   return error.category === 'timeout' ? 'timed_out' : 'failed';
 }
 
+function makeStdinErrorPayload(error: unknown): StructuredErrorPayload {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = error instanceof Error && 'code' in error
+    ? String((error as NodeJS.ErrnoException).code)
+    : undefined;
+  const detail = code === 'EPIPE'
+    ? 'Detached worker stdin closed before the prompt could be delivered (EPIPE).'
+    : `Detached worker stdin failed before the prompt could be delivered: ${message}`;
+  return {
+    error: true,
+    category: 'unknown',
+    message: detail,
+    exitCode: 1,
+    action: 'Inspect the detached worker process output and retry the command.',
+  };
+}
+
+function appendStderrEvent(jobId: string, line: string): void {
+  appendJobEvent(jobId, JSON.stringify({
+    type: 'stderr',
+    line,
+    timestamp: new Date().toISOString(),
+  }));
+}
+
 async function runWorkerAttempt(jobId: string, job: JobRecord): Promise<{
   exitCode: number;
   finalEvent?: NdjsonEvent;
   structuredError?: StructuredErrorPayload;
+  stderrLines: string[];
 }> {
   const child = spawn(process.execPath, [resolveCliEntrypoint(), ...buildWorkerArgs(job)], {
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -101,10 +134,28 @@ async function runWorkerAttempt(jobId: string, job: JobRecord): Promise<{
       CAVENDISH_ALLOW_PARTIAL: '1',
     },
   });
-  child.stdin.end(readJobPrompt(job.jobId));
+  if (typeof child.pid === 'number') {
+    updateJob(jobId, {
+      workerPid: child.pid,
+    });
+  }
 
   let finalEvent: NdjsonEvent | undefined;
   let structuredError: StructuredErrorPayload | undefined;
+  let stdinError: StructuredErrorPayload | undefined;
+  const stderrLines: string[] = [];
+
+  child.stdin.on('error', (error: unknown) => {
+    stdinError = makeStdinErrorPayload(error);
+    process.stderr.write(`[cavendish:jobs] ${stdinError.message}\n`);
+  });
+
+  try {
+    child.stdin.end(readJobPrompt(job.jobId));
+  } catch (error: unknown) {
+    stdinError = makeStdinErrorPayload(error);
+    process.stderr.write(`[cavendish:jobs] ${stdinError.message}\n`);
+  }
 
   const stdoutRl = createInterface({ input: child.stdout });
   stdoutRl.on('line', (line) => {
@@ -120,7 +171,10 @@ async function runWorkerAttempt(jobId: string, job: JobRecord): Promise<{
     const parsed = parseStructuredError(line);
     if (parsed !== undefined) {
       structuredError = parsed;
+      return;
     }
+    stderrLines.push(line);
+    appendStderrEvent(jobId, line);
   });
 
   const exitCode = await new Promise<number>((resolve, reject) => {
@@ -136,7 +190,8 @@ async function runWorkerAttempt(jobId: string, job: JobRecord): Promise<{
   return {
     exitCode,
     finalEvent,
-    structuredError,
+    structuredError: structuredError ?? stdinError,
+    stderrLines,
   };
 }
 
@@ -153,7 +208,7 @@ export async function runJobWorker(jobId: string): Promise<JobRunResult> {
   });
   appendJobState(jobId, 'job-running');
 
-  const { exitCode, finalEvent, structuredError } = await runWorkerAttempt(jobId, record);
+  const { exitCode, finalEvent, structuredError, stderrLines } = await runWorkerAttempt(jobId, record);
   const normalizedExitCode = structuredError === undefined ? normalizeFailureExitCode(exitCode) : exitCode;
 
   if (finalEvent !== undefined) {
@@ -169,6 +224,7 @@ export async function runJobWorker(jobId: string): Promise<JobRunResult> {
       url: finalEvent.url,
       partial: finalEvent.partial,
       exitCode,
+      workerPid: undefined,
     });
     appendJobState(jobId, `job-${status}`);
     notifyJobCompletion(record);
@@ -190,7 +246,9 @@ export async function runJobWorker(jobId: string): Promise<JobRunResult> {
   const errorPayload: StructuredErrorPayload = structuredError ?? {
     error: true,
     category: 'unknown',
-    message: `Detached worker exited without a final event (exit code: ${String(exitCode)})`,
+    message: stderrLines.length > 0
+      ? `Detached worker exited without a final event (exit code: ${String(exitCode)})\nDetached worker stderr:\n${stderrLines.join('\n')}`
+      : `Detached worker exited without a final event (exit code: ${String(exitCode)})`,
     exitCode: normalizedExitCode,
     action: 'Inspect the job error output and retry the command.',
   };
@@ -202,6 +260,7 @@ export async function runJobWorker(jobId: string): Promise<JobRunResult> {
       retryCount: (Number.isFinite(latest.retryCount) ? latest.retryCount : 0) + 1,
       lastRetriedAt: new Date().toISOString(),
       lastRetryError: errorPayload.message,
+      workerPid: undefined,
     }));
     appendJobState(jobId, 'job-queued');
     return {
@@ -220,6 +279,7 @@ export async function runJobWorker(jobId: string): Promise<JobRunResult> {
     error: errorPayload,
     exitCode: normalizedExitCode,
     partial: hasRecoveredContent ? true : undefined,
+    workerPid: undefined,
   });
   appendJobState(jobId, `job-${status}`);
   notifyJobCompletion(record);
@@ -256,10 +316,44 @@ export function markUnexpectedJobFailure(jobId: string, error: unknown, label = 
       completedAt: new Date().toISOString(),
       error: fallback,
       exitCode: 1,
+      workerPid: undefined,
     });
     appendJobState(jobId, 'job-failed');
     notifyJobCompletion(record);
   }
+}
+
+export function markJobRunnerKilled(jobId: string): void {
+  const fallback: StructuredErrorPayload = {
+    error: true,
+    category: 'runner_killed',
+    message: `Detached runner was interrupted while job ${jobId} was running.`,
+    exitCode: 11,
+    action: 'Restart the detached job; the runner process was interrupted before it could finish.',
+  };
+  writeJobError(jobId, fallback);
+  let job: JobRecord | undefined;
+  try {
+    job = readJob(jobId);
+  } catch (readError: unknown) {
+    progress(
+      `Detached runner failed to load job metadata for ${jobId}: ${readError instanceof Error ? readError.message : String(readError)}`,
+      false,
+    );
+    return;
+  }
+  if (job?.status !== 'running') {
+    return;
+  }
+  const record = updateJob(jobId, {
+    status: 'failed',
+    completedAt: new Date().toISOString(),
+    error: fallback,
+    exitCode: fallback.exitCode,
+    workerPid: undefined,
+  });
+  appendJobState(jobId, 'job-failed');
+  notifyJobCompletion(record);
 }
 
 export async function runJobWorkerOrExit(jobId: string): Promise<void> {

--- a/src/core/jobs/worker.ts
+++ b/src/core/jobs/worker.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process';
 import { createInterface } from 'node:readline';
 
-import type { StructuredErrorPayload } from '../errors.js';
+import { EXIT_CODES, type StructuredErrorPayload } from '../errors.js';
 import { progress } from '../output-handler.js';
 import type { NdjsonEvent } from '../output-handler.js';
 
@@ -388,7 +388,7 @@ export function markJobRunnerKilled(jobId: string): void {
     error: true,
     category: 'runner_killed',
     message: `Detached runner was interrupted while job ${jobId} was running.`,
-    exitCode: 11,
+    exitCode: EXIT_CODES.runner_killed,
     action: 'Restart the detached job; the runner process was interrupted before it could finish.',
   };
   writeJobError(jobId, fallback);

--- a/src/core/jobs/worker.ts
+++ b/src/core/jobs/worker.ts
@@ -156,6 +156,19 @@ function terminalStatusFromError(error: StructuredErrorPayload): Extract<JobStat
   return error.category === 'timeout' ? 'timed_out' : 'failed';
 }
 
+function terminalOutcomeFromRecord(job: JobRecord): JobRunResult | undefined {
+  if (job.status === 'completed') {
+    return { outcome: 'completed', record: job };
+  }
+  if (job.status === 'timed_out') {
+    return { outcome: 'timed_out', record: job, error: job.error };
+  }
+  if (job.status === 'failed' || job.status === 'cancelled') {
+    return { outcome: 'failed', record: job, error: job.error };
+  }
+  return undefined;
+}
+
 function makeStdinErrorPayload(error: unknown): StructuredErrorPayload {
   const message = error instanceof Error ? error.message : String(error);
   const code = error instanceof Error && 'code' in error
@@ -270,6 +283,13 @@ export async function runJobWorker(jobId: string): Promise<JobRunResult> {
 
   const { exitCode, finalEvent, structuredError, stderrLines } = await runWorkerAttempt(jobId, record);
   const normalizedExitCode = normalizeStructuredExitCode(exitCode, structuredError);
+  const terminalRecord = readJob(jobId);
+  if (terminalRecord !== undefined) {
+    const terminalOutcome = terminalOutcomeFromRecord(terminalRecord);
+    if (terminalOutcome !== undefined) {
+      return terminalOutcome;
+    }
+  }
 
   if (finalEvent !== undefined) {
     writeJobResult(jobId, {
@@ -303,7 +323,7 @@ export async function runJobWorker(jobId: string): Promise<JobRunResult> {
     });
   }
 
-  const errorPayload: StructuredErrorPayload = structuredError ?? {
+  const baseErrorPayload: StructuredErrorPayload = structuredError ?? {
     error: true,
     category: 'unknown',
     message: stderrLines.length > 0
@@ -311,6 +331,10 @@ export async function runJobWorker(jobId: string): Promise<JobRunResult> {
       : `Detached worker exited without a final event (exit code: ${String(exitCode)})`,
     exitCode: normalizedExitCode,
     action: 'Inspect the job error output and retry the command.',
+  };
+  const errorPayload: StructuredErrorPayload = {
+    ...baseErrorPayload,
+    exitCode: normalizedExitCode,
   };
 
   if (isLockContentionError(errorPayload)) {
@@ -384,14 +408,6 @@ export function markUnexpectedJobFailure(jobId: string, error: unknown, label = 
 }
 
 export function markJobRunnerKilled(jobId: string): void {
-  const fallback: StructuredErrorPayload = {
-    error: true,
-    category: 'runner_killed',
-    message: `Detached runner was interrupted while job ${jobId} was running.`,
-    exitCode: EXIT_CODES.runner_killed,
-    action: 'Restart the detached job; the runner process was interrupted before it could finish.',
-  };
-  writeJobError(jobId, fallback);
   let job: JobRecord | undefined;
   try {
     job = readJob(jobId);
@@ -405,6 +421,14 @@ export function markJobRunnerKilled(jobId: string): void {
   if (job?.status !== 'running') {
     return;
   }
+  const fallback: StructuredErrorPayload = {
+    error: true,
+    category: 'runner_killed',
+    message: `Detached runner was interrupted while job ${jobId} was running.`,
+    exitCode: EXIT_CODES.runner_killed,
+    action: 'Restart the detached job; the runner process was interrupted before it could finish.',
+  };
+  writeJobError(jobId, fallback);
   const record = updateJob(jobId, {
     status: 'failed',
     completedAt: new Date().toISOString(),

--- a/src/core/report.ts
+++ b/src/core/report.ts
@@ -101,6 +101,23 @@ const SKIP_SELECTORS = selectorSet([
   'REPORT_DOM_QUERY',
 ]);
 
+function isDeepResearchSelector(key: SelectorKey): boolean {
+  return key.startsWith('DEEP_RESEARCH_') && key !== 'DEEP_RESEARCH_FRAME_URL';
+}
+
+async function countSelector(page: Page, key: SelectorKey, selector: string): Promise<number> {
+  const pageCount = await page.locator(selector).count();
+  if (!isDeepResearchSelector(key)) {
+    return pageCount;
+  }
+  const frameCounts = await Promise.all(
+    page.frames()
+      .filter((frame) => frame.url().includes(SELECTORS.DEEP_RESEARCH_FRAME_URL))
+      .map((frame) => frame.locator(selector).count()),
+  );
+  return frameCounts.reduce((sum, count) => sum + count, pageCount);
+}
+
 export function categorizeSelector(name: string): SelectorCategory {
   if (HOMEPAGE_SELECTORS.has(name)) {return 'homepage';}
   if (AUTH_SELECTORS.has(name)) {return 'auth';}
@@ -123,7 +140,7 @@ export async function validateAllSelectors(
     keys.map(async (key): Promise<SelectorResult> => {
       const selector = SELECTORS[key];
       try {
-        const count = await page.locator(selector).count();
+        const count = await countSelector(page, key, selector);
         return { name: key, selector, count, category: categorizeSelector(key) };
       } catch (error: unknown) {
         progress('Warning: selector ' + key + ' failed: ' + errorMessage(error), quiet);

--- a/src/core/report.ts
+++ b/src/core/report.ts
@@ -106,16 +106,15 @@ function isDeepResearchSelector(key: SelectorKey): boolean {
 }
 
 async function countSelector(page: Page, key: SelectorKey, selector: string): Promise<number> {
-  const pageCount = await page.locator(selector).count();
   if (!isDeepResearchSelector(key)) {
-    return pageCount;
+    return page.locator(selector).count();
   }
   const frameCounts = await Promise.all(
     page.frames()
       .filter((frame) => frame.url().includes(SELECTORS.DEEP_RESEARCH_FRAME_URL))
       .map((frame) => frame.locator(selector).count()),
   );
-  return frameCounts.reduce((sum, count) => sum + count, pageCount);
+  return frameCounts.reduce((sum, count) => sum + count, 0);
 }
 
 export function categorizeSelector(name: string): SelectorCategory {

--- a/tests/ask-detach.test.ts
+++ b/tests/ask-detach.test.ts
@@ -7,6 +7,7 @@ const SAFE_JOB_PATH = join(process.cwd(), '.tmp-tests', 'job.json');
 const SAFE_EVENTS_PATH = join(process.cwd(), '.tmp-tests', 'events.ndjson');
 
 let jsonRawMock: ReturnType<typeof vi.fn>;
+let failStructuredMock: ReturnType<typeof vi.fn>;
 let failValidationMock: ReturnType<typeof vi.fn>;
 let submitDetachedJobMock: ReturnType<typeof vi.fn>;
 let readStdinMock: ReturnType<typeof vi.fn>;
@@ -67,12 +68,13 @@ vi.mock('../src/core/jobs/submit.js', () => {
 
 vi.mock('../src/core/output-handler.js', () => {
   jsonRawMock = vi.fn();
+  failStructuredMock = vi.fn();
   failValidationMock = vi.fn();
   return {
     emitChunk: vi.fn(),
     emitFinal: vi.fn(),
     errorMessage: vi.fn((e: unknown): string => (e instanceof Error ? e.message : String(e))),
-    failStructured: vi.fn(),
+    failStructured: failStructuredMock,
     failValidation: failValidationMock,
     json: vi.fn(),
     jsonRaw: jsonRawMock,
@@ -237,6 +239,36 @@ describe('ask --detach', () => {
     // Default (no --detach, no --sync) should submit a detached job
     expect(submitDetachedJobMock).toHaveBeenCalledOnce();
     expect(failValidationMock).not.toHaveBeenCalled();
+  });
+
+  it('routes detached submit failures through failStructured', async () => {
+    submitDetachedJobMock.mockRejectedValueOnce(new Error('runner startup failed'));
+    const { askCommand } = await import('../src/commands/ask.js');
+    const run = askCommand.run;
+    if (run === undefined) {
+      throw new Error('askCommand.run is undefined');
+    }
+
+    await run({
+      args: {
+        _: [],
+        prompt: 'hello',
+        model: 'Pro',
+        quiet: false,
+        verbose: false,
+        stream: false,
+        dryRun: false,
+        format: 'json',
+        continue: false,
+        agent: false,
+        detach: true,
+      } as never,
+      rawArgs: [],
+      cmd: askCommand,
+    });
+
+    expect(failStructuredMock).toHaveBeenCalledWith(expect.any(Error), 'json');
+    expect(jsonRawMock).not.toHaveBeenCalled();
   });
 
   it('--stream auto-implies sync (no detach even with --detach)', async () => {

--- a/tests/deep-research-detach.test.ts
+++ b/tests/deep-research-detach.test.ts
@@ -7,6 +7,7 @@ const SAFE_JOB_PATH = join(process.cwd(), '.tmp-tests', 'dr-job.json');
 const SAFE_EVENTS_PATH = join(process.cwd(), '.tmp-tests', 'dr-events.ndjson');
 
 let jsonRawMock: ReturnType<typeof vi.fn>;
+let failStructuredMock: ReturnType<typeof vi.fn>;
 let submitDetachedJobMock: ReturnType<typeof vi.fn>;
 let withDriverMock: ReturnType<typeof vi.fn>;
 
@@ -42,10 +43,12 @@ vi.mock('../src/core/jobs/submit.js', () => {
 
 vi.mock('../src/core/output-handler.js', () => {
   jsonRawMock = vi.fn();
+  failStructuredMock = vi.fn();
   return {
     emitFinal: vi.fn(),
     emitState: vi.fn(),
     errorMessage: vi.fn((e: unknown): string => (e instanceof Error ? e.message : String(e))),
+    failStructured: failStructuredMock,
     failValidation: vi.fn(),
     json: vi.fn(),
     jsonRaw: jsonRawMock,
@@ -176,6 +179,34 @@ describe('deep-research --detach', () => {
 
     // Default (no --detach, no --sync) should submit a detached job
     expect(submitDetachedJobMock).toHaveBeenCalledOnce();
+    expect(withDriverMock).not.toHaveBeenCalled();
+  });
+
+  it('routes detached submit failures through failStructured', async () => {
+    submitDetachedJobMock.mockRejectedValueOnce(new Error('runner startup failed'));
+    const { deepResearchCommand } = await import('../src/commands/deep-research.js');
+    const run = deepResearchCommand.run;
+    if (run === undefined) {
+      throw new Error('deepResearchCommand.run is undefined');
+    }
+
+    await run({
+      args: {
+        _: [],
+        prompt: 'research topic',
+        quiet: false,
+        verbose: false,
+        stream: false,
+        dryRun: false,
+        format: 'json',
+        detach: true,
+      } as never,
+      rawArgs: [],
+      cmd: deepResearchCommand,
+    });
+
+    expect(failStructuredMock).toHaveBeenCalledWith(expect.any(Error), 'json');
+    expect(jsonRawMock).not.toHaveBeenCalled();
     expect(withDriverMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
+import { MENU_LABELS, SELECTORS } from '../src/constants/selectors.js';
 import {
   type CheckStatus,
   type DoctorCheck,
   buildDoctorResult,
   buildSummary,
+  checkGoogleDrive,
   formatTextOutput,
 } from '../src/core/doctor.js';
 
@@ -44,6 +46,55 @@ describe('buildDoctorResult', () => {
 
     expect(result.checks).toBe(checks);
     expect(result.summary).toEqual({ total: 1, pass: 1, fail: 0, skip: 0 });
+  });
+});
+
+describe('checkGoogleDrive', () => {
+  it('opens the composer plus menu and passes when the Google Drive entry is visible', async () => {
+    const interactions: string[] = [];
+    const page = {
+      keyboard: {
+        press: (key: string): Promise<void> => {
+          interactions.push(`key:${key}`);
+          return Promise.resolve();
+        },
+      },
+      locator: (selector: string) => {
+        if (selector === SELECTORS.COMPOSER_PLUS_BUTTON) {
+          return {
+            count: () => Promise.resolve(1),
+            first: () => ({
+              click: () => {
+                interactions.push('click:plus');
+                return Promise.resolve();
+              },
+            }),
+          };
+        }
+        if (selector === SELECTORS.MENU_ITEM) {
+          return {
+            first: () => ({
+              waitFor: () => Promise.resolve(),
+            }),
+            filter: ({ hasText }: { hasText: string }) => ({
+              count: () => Promise.resolve(
+                MENU_LABELS.ADD_FROM_GOOGLE_DRIVE.some((label) => label === hasText) ? 1 : 0,
+              ),
+            }),
+          };
+        }
+        throw new Error(`Unexpected selector: ${selector}`);
+      },
+    };
+
+    const result = await checkGoogleDrive(page as unknown as Parameters<typeof checkGoogleDrive>[0]);
+
+    expect(result).toEqual({
+      name: 'gdrive_picker',
+      status: 'pass',
+      detail: 'Google Drive menu entry found',
+    });
+    expect(interactions).toEqual(['click:plus', 'key:Escape']);
   });
 });
 

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -168,16 +168,23 @@ describe('checkGoogleDrive', () => {
   });
 
   it('skips when the Google Drive entry exists in DOM but is hidden', async () => {
+    const interactions: string[] = [];
     const page = {
       keyboard: {
-        press: () => Promise.resolve(),
+        press: (key: string): Promise<void> => {
+          interactions.push(`key:${key}`);
+          return Promise.resolve();
+        },
       },
       locator: (selector: string) => {
         if (selector === SELECTORS.COMPOSER_PLUS_BUTTON) {
           return {
             count: () => Promise.resolve(1),
             first: () => ({
-              click: () => Promise.resolve(),
+              click: () => {
+                interactions.push('click:plus');
+                return Promise.resolve();
+              },
             }),
           };
         }
@@ -200,6 +207,7 @@ describe('checkGoogleDrive', () => {
 
     expect(result.status).toBe('skip');
     expect(result.detail).toBe('Composer + menu opened but Google Drive menu entry was not found');
+    expect(interactions).toEqual(['click:plus', 'key:Escape']);
   });
 
   it('fails with actionable detail when the composer plus menu cannot open', async () => {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -61,13 +61,15 @@ describe('checkGoogleDrive', () => {
       },
       locator: (selector: string) => {
         if (selector === SELECTORS.COMPOSER_PLUS_BUTTON) {
+          const click = (): Promise<void> => {
+            interactions.push('click:plus');
+            return Promise.resolve();
+          };
           return {
             count: () => Promise.resolve(1),
+            click,
             first: () => ({
-              click: () => {
-                interactions.push('click:plus');
-                return Promise.resolve();
-              },
+              click,
             }),
           };
         }
@@ -95,6 +97,44 @@ describe('checkGoogleDrive', () => {
       detail: 'Google Drive menu entry found',
     });
     expect(interactions).toEqual(['click:plus', 'key:Escape']);
+  });
+
+  it('fails with actionable detail when the composer plus menu cannot open', async () => {
+    const page = {
+      keyboard: {
+        press: () => Promise.resolve(),
+      },
+      locator: (selector: string) => {
+        if (selector === SELECTORS.COMPOSER_PLUS_BUTTON) {
+          const click = (): Promise<void> => Promise.reject(new Error('menu blocked'));
+          return {
+            count: () => Promise.resolve(1),
+            click,
+            first: () => ({
+              click,
+            }),
+          };
+        }
+        if (selector === SELECTORS.MENU_ITEM) {
+          return {
+            first: () => ({
+              waitFor: () => Promise.resolve(),
+            }),
+            filter: () => ({
+              count: () => Promise.resolve(0),
+            }),
+          };
+        }
+        throw new Error(`Unexpected selector: ${selector}`);
+      },
+    };
+
+    const result = await checkGoogleDrive(page as unknown as Parameters<typeof checkGoogleDrive>[0]);
+
+    expect(result.name).toBe('gdrive_picker');
+    expect(result.status).toBe('fail');
+    expect(result.detail).toContain('menu blocked');
+    expect(result.action).toContain('composer + menu');
   });
 });
 

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -61,15 +61,15 @@ describe('checkGoogleDrive', () => {
       },
       locator: (selector: string) => {
         if (selector === SELECTORS.COMPOSER_PLUS_BUTTON) {
-          const click = (): Promise<void> => {
+          const firstClick = (): Promise<void> => {
             interactions.push('click:plus');
             return Promise.resolve();
           };
           return {
             count: () => Promise.resolve(1),
-            click,
+            click: () => Promise.reject(new Error('strict mode violation')),
             first: () => ({
-              click,
+              click: firstClick,
             }),
           };
         }
@@ -95,6 +95,57 @@ describe('checkGoogleDrive', () => {
       name: 'gdrive_picker',
       status: 'pass',
       detail: 'Google Drive menu entry found',
+    });
+    expect(interactions).toEqual(['click:plus', 'key:Escape']);
+  });
+
+  it('skips when the composer plus menu opens but the Google Drive entry is absent', async () => {
+    const interactions: string[] = [];
+    const page = {
+      keyboard: {
+        press: (key: string): Promise<void> => {
+          interactions.push(`key:${key}`);
+          return Promise.resolve();
+        },
+      },
+      locator: (selector: string) => {
+        if (selector === SELECTORS.COMPOSER_PLUS_BUTTON) {
+          return {
+            count: () => Promise.resolve(1),
+            click: () => Promise.reject(new Error('strict mode violation')),
+            first: () => ({
+              click: () => {
+                interactions.push('click:plus');
+                return Promise.resolve();
+              },
+            }),
+          };
+        }
+        if (selector === SELECTORS.MENU_ITEM) {
+          return {
+            first: () => ({
+              waitFor: () => Promise.resolve(),
+            }),
+            filter: ({ hasText }: { hasText: string }) => {
+              if (!MENU_LABELS.ADD_FROM_GOOGLE_DRIVE.some((label) => label === hasText)) {
+                throw new Error(`Unexpected menu label: ${hasText}`);
+              }
+              return {
+                count: () => Promise.resolve(0),
+              };
+            },
+          };
+        }
+        throw new Error(`Unexpected selector: ${selector}`);
+      },
+    };
+
+    const result = await checkGoogleDrive(page as unknown as Parameters<typeof checkGoogleDrive>[0]);
+
+    expect(result).toEqual({
+      name: 'gdrive_picker',
+      status: 'skip',
+      detail: 'Composer + menu opened but Google Drive menu entry was not found',
     });
     expect(interactions).toEqual(['click:plus', 'key:Escape']);
   });

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -17,6 +17,16 @@ interface MockFilteredMenuItem {
   };
 }
 
+interface GoogleDrivePageMock {
+  page: Parameters<typeof checkGoogleDrive>[0];
+  interactions: string[];
+}
+
+interface GoogleDrivePageMockOptions {
+  menuItemForLabel?: (label: string) => MockFilteredMenuItem;
+  plusClick?: (interactions: string[]) => Promise<void>;
+}
+
 function isGoogleDriveMenuLabel(label: string): boolean {
   return MENU_LABELS.ADD_FROM_GOOGLE_DRIVE.some((candidate) => candidate === label);
 }
@@ -28,6 +38,50 @@ function makeFilteredMenuItem(count: number, visible: boolean): MockFilteredMenu
       isVisible: () => Promise.resolve(visible),
     }),
   };
+}
+
+function defaultPlusClick(interactions: string[]): Promise<void> {
+  interactions.push('click:plus');
+  return Promise.resolve();
+}
+
+function createGoogleDrivePageMock(options: GoogleDrivePageMockOptions = {}): GoogleDrivePageMock {
+  const interactions: string[] = [];
+  const click = (): Promise<void> => (options.plusClick ?? defaultPlusClick)(interactions);
+  const menuItemForLabel = options.menuItemForLabel
+    ?? ((label: string): MockFilteredMenuItem => makeFilteredMenuItem(
+      isGoogleDriveMenuLabel(label) ? 1 : 0,
+      isGoogleDriveMenuLabel(label),
+    ));
+  const page = {
+    keyboard: {
+      press: (key: string): Promise<void> => {
+        interactions.push(`key:${key}`);
+        return Promise.resolve();
+      },
+    },
+    locator: (selector: string) => {
+      if (selector === SELECTORS.COMPOSER_PLUS_BUTTON) {
+        return {
+          count: () => Promise.resolve(1),
+          click,
+          first: () => ({
+            click,
+          }),
+        };
+      }
+      if (selector === SELECTORS.MENU_ITEM) {
+        return {
+          first: () => ({
+            waitFor: () => Promise.resolve(),
+          }),
+          filter: ({ hasText }: { hasText: string }) => menuItemForLabel(hasText),
+        };
+      }
+      throw new Error(`Unexpected selector: ${selector}`);
+    },
+  };
+  return { page: page as unknown as Parameters<typeof checkGoogleDrive>[0], interactions };
 }
 
 describe('buildSummary', () => {
@@ -71,44 +125,9 @@ describe('buildDoctorResult', () => {
 
 describe('checkGoogleDrive', () => {
   it('opens the composer plus menu and passes when the Google Drive entry is visible', async () => {
-    const interactions: string[] = [];
-    const page = {
-      keyboard: {
-        press: (key: string): Promise<void> => {
-          interactions.push(`key:${key}`);
-          return Promise.resolve();
-        },
-      },
-      locator: (selector: string) => {
-        if (selector === SELECTORS.COMPOSER_PLUS_BUTTON) {
-          const firstClick = (): Promise<void> => {
-            interactions.push('click:plus');
-            return Promise.resolve();
-          };
-          return {
-            count: () => Promise.resolve(1),
-            click: firstClick,
-            first: () => ({
-              click: firstClick,
-            }),
-          };
-        }
-        if (selector === SELECTORS.MENU_ITEM) {
-          return {
-            first: () => ({
-              waitFor: () => Promise.resolve(),
-            }),
-            filter: ({ hasText }: { hasText: string }) => makeFilteredMenuItem(
-              isGoogleDriveMenuLabel(hasText) ? 1 : 0,
-              isGoogleDriveMenuLabel(hasText),
-            ),
-          };
-        }
-        throw new Error(`Unexpected selector: ${selector}`);
-      },
-    };
+    const { page, interactions } = createGoogleDrivePageMock();
 
-    const result = await checkGoogleDrive(page as unknown as Parameters<typeof checkGoogleDrive>[0]);
+    const result = await checkGoogleDrive(page);
 
     expect(result).toEqual({
       name: 'gdrive_picker',
@@ -119,46 +138,16 @@ describe('checkGoogleDrive', () => {
   });
 
   it('skips when the composer plus menu opens but the Google Drive entry is absent', async () => {
-    const interactions: string[] = [];
-    const page = {
-      keyboard: {
-        press: (key: string): Promise<void> => {
-          interactions.push(`key:${key}`);
-          return Promise.resolve();
-        },
-      },
-      locator: (selector: string) => {
-        if (selector === SELECTORS.COMPOSER_PLUS_BUTTON) {
-          const click = (): Promise<void> => {
-            interactions.push('click:plus');
-            return Promise.resolve();
-          };
-          return {
-            count: () => Promise.resolve(1),
-            click,
-            first: () => ({
-              click,
-            }),
-          };
+    const { page, interactions } = createGoogleDrivePageMock({
+      menuItemForLabel: (label) => {
+        if (!isGoogleDriveMenuLabel(label)) {
+          throw new Error(`Unexpected menu label: ${label}`);
         }
-        if (selector === SELECTORS.MENU_ITEM) {
-          return {
-            first: () => ({
-              waitFor: () => Promise.resolve(),
-            }),
-            filter: ({ hasText }: { hasText: string }) => {
-              if (!MENU_LABELS.ADD_FROM_GOOGLE_DRIVE.some((label) => label === hasText)) {
-                throw new Error(`Unexpected menu label: ${hasText}`);
-              }
-              return makeFilteredMenuItem(0, false);
-            },
-          };
-        }
-        throw new Error(`Unexpected selector: ${selector}`);
+        return makeFilteredMenuItem(0, false);
       },
-    };
+    });
 
-    const result = await checkGoogleDrive(page as unknown as Parameters<typeof checkGoogleDrive>[0]);
+    const result = await checkGoogleDrive(page);
 
     expect(result).toEqual({
       name: 'gdrive_picker',
@@ -169,42 +158,14 @@ describe('checkGoogleDrive', () => {
   });
 
   it('skips when the Google Drive entry exists in DOM but is hidden', async () => {
-    const interactions: string[] = [];
-    const page = {
-      keyboard: {
-        press: (key: string): Promise<void> => {
-          interactions.push(`key:${key}`);
-          return Promise.resolve();
-        },
-      },
-      locator: (selector: string) => {
-        if (selector === SELECTORS.COMPOSER_PLUS_BUTTON) {
-          return {
-            count: () => Promise.resolve(1),
-            first: () => ({
-              click: () => {
-                interactions.push('click:plus');
-                return Promise.resolve();
-              },
-            }),
-          };
-        }
-        if (selector === SELECTORS.MENU_ITEM) {
-          return {
-            first: () => ({
-              waitFor: () => Promise.resolve(),
-            }),
-            filter: ({ hasText }: { hasText: string }) => makeFilteredMenuItem(
-              isGoogleDriveMenuLabel(hasText) ? 1 : 0,
-              false,
-            ),
-          };
-        }
-        throw new Error(`Unexpected selector: ${selector}`);
-      },
-    };
+    const { page, interactions } = createGoogleDrivePageMock({
+      menuItemForLabel: (label) => makeFilteredMenuItem(
+        isGoogleDriveMenuLabel(label) ? 1 : 0,
+        false,
+      ),
+    });
 
-    const result = await checkGoogleDrive(page as unknown as Parameters<typeof checkGoogleDrive>[0]);
+    const result = await checkGoogleDrive(page);
 
     expect(result.status).toBe('skip');
     expect(result.detail).toBe('Composer + menu opened but Google Drive menu entry was not found');
@@ -212,36 +173,12 @@ describe('checkGoogleDrive', () => {
   });
 
   it('fails with actionable detail when the composer plus menu cannot open', async () => {
-    const page = {
-      keyboard: {
-        press: () => Promise.resolve(),
-      },
-      locator: (selector: string) => {
-        if (selector === SELECTORS.COMPOSER_PLUS_BUTTON) {
-          const click = (): Promise<void> => Promise.reject(new Error('menu blocked'));
-          return {
-            count: () => Promise.resolve(1),
-            click,
-            first: () => ({
-              click,
-            }),
-          };
-        }
-        if (selector === SELECTORS.MENU_ITEM) {
-          return {
-            first: () => ({
-              waitFor: () => Promise.resolve(),
-            }),
-            filter: () => ({
-              count: () => Promise.resolve(0),
-            }),
-          };
-        }
-        throw new Error(`Unexpected selector: ${selector}`);
-      },
-    };
+    const { page } = createGoogleDrivePageMock({
+      plusClick: () => Promise.reject(new Error('menu blocked')),
+      menuItemForLabel: () => makeFilteredMenuItem(0, false),
+    });
 
-    const result = await checkGoogleDrive(page as unknown as Parameters<typeof checkGoogleDrive>[0]);
+    const result = await checkGoogleDrive(page);
 
     expect(result.name).toBe('gdrive_picker');
     expect(result.status).toBe('fail');

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -10,6 +10,26 @@ import {
   formatTextOutput,
 } from '../src/core/doctor.js';
 
+interface MockFilteredMenuItem {
+  count: () => Promise<number>;
+  first: () => {
+    isVisible: () => Promise<boolean>;
+  };
+}
+
+function isGoogleDriveMenuLabel(label: string): boolean {
+  return MENU_LABELS.ADD_FROM_GOOGLE_DRIVE.some((candidate) => candidate === label);
+}
+
+function makeFilteredMenuItem(count: number, visible: boolean): MockFilteredMenuItem {
+  return {
+    count: () => Promise.resolve(count),
+    first: () => ({
+      isVisible: () => Promise.resolve(visible),
+    }),
+  };
+}
+
 describe('buildSummary', () => {
   it('counts pass/fail/skip correctly', () => {
     const checks: DoctorCheck[] = [
@@ -78,11 +98,10 @@ describe('checkGoogleDrive', () => {
             first: () => ({
               waitFor: () => Promise.resolve(),
             }),
-            filter: ({ hasText }: { hasText: string }) => ({
-              count: () => Promise.resolve(
-                MENU_LABELS.ADD_FROM_GOOGLE_DRIVE.some((label) => label === hasText) ? 1 : 0,
-              ),
-            }),
+            filter: ({ hasText }: { hasText: string }) => makeFilteredMenuItem(
+              isGoogleDriveMenuLabel(hasText) ? 1 : 0,
+              isGoogleDriveMenuLabel(hasText),
+            ),
           };
         }
         throw new Error(`Unexpected selector: ${selector}`);
@@ -130,9 +149,7 @@ describe('checkGoogleDrive', () => {
               if (!MENU_LABELS.ADD_FROM_GOOGLE_DRIVE.some((label) => label === hasText)) {
                 throw new Error(`Unexpected menu label: ${hasText}`);
               }
-              return {
-                count: () => Promise.resolve(0),
-              };
+              return makeFilteredMenuItem(0, false);
             },
           };
         }
@@ -148,6 +165,41 @@ describe('checkGoogleDrive', () => {
       detail: 'Composer + menu opened but Google Drive menu entry was not found',
     });
     expect(interactions).toEqual(['click:plus', 'key:Escape']);
+  });
+
+  it('skips when the Google Drive entry exists in DOM but is hidden', async () => {
+    const page = {
+      keyboard: {
+        press: () => Promise.resolve(),
+      },
+      locator: (selector: string) => {
+        if (selector === SELECTORS.COMPOSER_PLUS_BUTTON) {
+          return {
+            count: () => Promise.resolve(1),
+            first: () => ({
+              click: () => Promise.resolve(),
+            }),
+          };
+        }
+        if (selector === SELECTORS.MENU_ITEM) {
+          return {
+            first: () => ({
+              waitFor: () => Promise.resolve(),
+            }),
+            filter: ({ hasText }: { hasText: string }) => makeFilteredMenuItem(
+              isGoogleDriveMenuLabel(hasText) ? 1 : 0,
+              false,
+            ),
+          };
+        }
+        throw new Error(`Unexpected selector: ${selector}`);
+      },
+    };
+
+    const result = await checkGoogleDrive(page as unknown as Parameters<typeof checkGoogleDrive>[0]);
+
+    expect(result.status).toBe('skip');
+    expect(result.detail).toBe('Composer + menu opened but Google Drive menu entry was not found');
   });
 
   it('fails with actionable detail when the composer plus menu cannot open', async () => {

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -87,7 +87,7 @@ describe('checkGoogleDrive', () => {
           };
           return {
             count: () => Promise.resolve(1),
-            click: () => Promise.reject(new Error('strict mode violation')),
+            click: firstClick,
             first: () => ({
               click: firstClick,
             }),
@@ -129,14 +129,15 @@ describe('checkGoogleDrive', () => {
       },
       locator: (selector: string) => {
         if (selector === SELECTORS.COMPOSER_PLUS_BUTTON) {
+          const click = (): Promise<void> => {
+            interactions.push('click:plus');
+            return Promise.resolve();
+          };
           return {
             count: () => Promise.resolve(1),
-            click: () => Promise.reject(new Error('strict mode violation')),
+            click,
             first: () => ({
-              click: () => {
-                interactions.push('click:plus');
-                return Promise.resolve();
-              },
+              click,
             }),
           };
         }

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -74,6 +74,9 @@ describe('EXIT_CODES', () => {
       'auth_expired',
       'cloudflare_blocked',
       'selector_miss',
+      'browser_disconnected',
+      'job_no_progress',
+      'runner_killed',
       'timeout',
       'unknown',
     ];
@@ -192,6 +195,22 @@ describe('classifyError', () => {
       'Timeout 30000ms exceeded. waiting for locator(\'[data-testid="prompt-textarea"]\')',
     );
     expect(classifyError(err).category).toBe('selector_miss');
+  });
+
+  it('classifies Playwright browser closure before locator selector misses', () => {
+    const err = new Error(
+      'Timeout 30000ms exceeded. waiting for locator("[data-testid=\\"stop-button\\"]")\nTarget page, context or browser has been closed',
+    );
+    const classified = classifyError(err);
+
+    expect(classified.category).toBe('browser_disconnected');
+    expect(classified.action).toBe('Chrome was closed or crashed. Restart Chrome and re-run the command.');
+  });
+
+  it('classifies target closed as browser disconnected', () => {
+    const err = new Error('Target closed while waiting for selector');
+
+    expect(classifyError(err).category).toBe('browser_disconnected');
   });
 
   it('classifies timeout with "selector" in human text as timeout, not selector_miss', () => {

--- a/tests/jobs-command.test.ts
+++ b/tests/jobs-command.test.ts
@@ -21,6 +21,7 @@ vi.mock('../src/core/cli-args.js', () => ({
 }));
 
 vi.mock('../src/core/jobs/store.js', () => ({
+  getJobEventsPath: vi.fn((jobId: string) => `/tmp/cavendish-test-events-${jobId}.ndjson`),
   listJobs: vi.fn(() => [
     {
       jobId: 'job-1',
@@ -392,6 +393,142 @@ describe('jobs command', () => {
       expect(firstCall[1]).toBe('json');
       expect(jsonRawMock).not.toHaveBeenCalled();
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not fail jobs wait for an alive worker even when updatedAt is old', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-14T00:06:00.000Z'));
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+    try {
+      const { jobsCommand } = await import('../src/commands/jobs.js');
+      const store = await import('../src/core/jobs/store.js');
+      const runningJob = {
+        jobId: 'job-live',
+        kind: 'deep-research',
+        status: 'running',
+        submittedAt: '2026-03-14T00:00:00.000Z',
+        updatedAt: '2026-03-14T00:00:00.000Z',
+        retryCount: 0,
+        workerPid: 12345,
+      } as never;
+      const completedJob = {
+        jobId: 'job-live',
+        kind: 'deep-research',
+        status: 'completed',
+        submittedAt: '2026-03-14T00:00:00.000Z',
+        updatedAt: '2026-03-14T00:06:02.000Z',
+        retryCount: 0,
+        workerPid: undefined,
+      } as never;
+      const readJobMock = vi.mocked(store.readJob);
+      for (let i = 0; i < 6; i += 1) {
+        readJobMock.mockReturnValueOnce(runningJob);
+      }
+      readJobMock.mockReturnValue(completedJob);
+      vi.mocked(store.readJobResult).mockReturnValue({
+        event: {
+          content: 'deep research result',
+          model: 'deep-research',
+          partial: false,
+          timeoutSec: 0,
+          timestamp: '2026-03-14T00:06:02.000Z',
+        },
+      } as never);
+
+      const subCommands = jobsCommand.subCommands as unknown as {
+        wait?: RunnableCommand;
+      };
+      const waitCommand = subCommands.wait;
+      const run = waitCommand?.run;
+      if (waitCommand === undefined || run === undefined) {
+        throw new Error('jobsCommand.subCommands.wait.run is undefined');
+      }
+
+      const runPromise = Promise.resolve(run({
+        args: {
+          _: [],
+          jobId: 'job-live',
+          poll: '1',
+          timeout: undefined,
+          format: 'json',
+          quiet: false,
+          verbose: false,
+        } as never,
+        rawArgs: [],
+        cmd: waitCommand,
+      }));
+      await vi.advanceTimersByTimeAsync(1400);
+      await runPromise;
+
+      expect(killSpy).toHaveBeenCalledWith(12345, 0);
+      expect(failStructuredMock).not.toHaveBeenCalled();
+      expect(jsonRawMock).toHaveBeenCalledWith(expect.objectContaining({
+        jobId: 'job-live',
+        status: 'completed',
+        content: 'deep research result',
+      }));
+    } finally {
+      killSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('fails jobs wait with no-progress when an old running worker pid is dead', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-14T00:06:00.000Z'));
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      const error = new Error('no such process') as NodeJS.ErrnoException;
+      error.code = 'ESRCH';
+      throw error;
+    });
+    try {
+      const { jobsCommand } = await import('../src/commands/jobs.js');
+      const store = await import('../src/core/jobs/store.js');
+      vi.mocked(store.readJob).mockReturnValue({
+        jobId: 'job-dead',
+        kind: 'ask',
+        status: 'running',
+        submittedAt: '2026-03-14T00:00:00.000Z',
+        updatedAt: '2026-03-14T00:00:00.000Z',
+        retryCount: 0,
+        workerPid: 54321,
+      } as never);
+
+      const subCommands = jobsCommand.subCommands as unknown as {
+        wait?: RunnableCommand;
+      };
+      const waitCommand = subCommands.wait;
+      const run = waitCommand?.run;
+      if (waitCommand === undefined || run === undefined) {
+        throw new Error('jobsCommand.subCommands.wait.run is undefined');
+      }
+
+      await run({
+        args: {
+          _: [],
+          jobId: 'job-dead',
+          poll: '1',
+          timeout: undefined,
+          format: 'json',
+          quiet: false,
+          verbose: false,
+        } as never,
+        rawArgs: [],
+        cmd: waitCommand,
+      });
+
+      expect(killSpy).toHaveBeenCalledWith(54321, 0);
+      expect(failStructuredMock).toHaveBeenCalledTimes(1);
+      const firstCall = failStructuredMock.mock.calls[0] as unknown as [
+        { category?: string; message?: string },
+        string,
+      ];
+      expect(firstCall[0].category).toBe('job_no_progress');
+      expect(firstCall[0].message).toContain('no progress');
+    } finally {
+      killSpy.mockRestore();
       vi.useRealTimers();
     }
   });

--- a/tests/jobs-command.test.ts
+++ b/tests/jobs-command.test.ts
@@ -339,4 +339,60 @@ describe('jobs command', () => {
       }),
     );
   });
+
+  it('fails jobs wait with a no-progress error when a running job has stale updatedAt', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-14T00:06:00.000Z'));
+    try {
+      const { jobsCommand } = await import('../src/commands/jobs.js');
+      const store = await import('../src/core/jobs/store.js');
+      vi.mocked(store.readJob).mockReturnValue({
+        jobId: 'job-stalled',
+        kind: 'ask',
+        status: 'running',
+        submittedAt: '2026-03-14T00:00:00.000Z',
+        updatedAt: '2026-03-14T00:00:00.000Z',
+        retryCount: 0,
+      } as never);
+
+      const subCommands = jobsCommand.subCommands as unknown as {
+        wait?: RunnableCommand;
+      };
+      const waitCommand = subCommands.wait;
+      const run = waitCommand?.run;
+      if (waitCommand === undefined || run === undefined) {
+        throw new Error('jobsCommand.subCommands.wait.run is undefined');
+      }
+
+      await run({
+        args: {
+          _: [],
+          jobId: 'job-stalled',
+          poll: '1',
+          timeout: undefined,
+          format: 'json',
+          quiet: false,
+          verbose: false,
+        } as never,
+        rawArgs: [],
+        cmd: waitCommand,
+      });
+
+      expect(progressMock).toHaveBeenCalledWith(
+        expect.stringContaining('no progress'),
+        false,
+      );
+      expect(failStructuredMock).toHaveBeenCalledTimes(1);
+      const firstCall = failStructuredMock.mock.calls[0] as unknown as [
+        { category?: string; message?: string },
+        string,
+      ];
+      expect(firstCall[0].category).toBe('job_no_progress');
+      expect(firstCall[0].message).toContain('no progress');
+      expect(firstCall[1]).toBe('json');
+      expect(jsonRawMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/tests/jobs-command.test.ts
+++ b/tests/jobs-command.test.ts
@@ -532,4 +532,81 @@ describe('jobs command', () => {
       vi.useRealTimers();
     }
   });
+
+  it('fails jobs wait with no-progress for explicit unlimited timeout when worker pid is dead', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-14T00:06:00.000Z'));
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      const error = new Error('no such process') as NodeJS.ErrnoException;
+      error.code = 'ESRCH';
+      throw error;
+    });
+    try {
+      const { jobsCommand } = await import('../src/commands/jobs.js');
+      const store = await import('../src/core/jobs/store.js');
+      vi.mocked(store.readJob)
+        .mockReturnValueOnce({
+          jobId: 'job-dead-explicit',
+          kind: 'ask',
+          status: 'running',
+          submittedAt: '2026-03-14T00:00:00.000Z',
+          updatedAt: '2026-03-14T00:00:00.000Z',
+          retryCount: 0,
+          workerPid: 65432,
+        } as never)
+        .mockReturnValue({
+          jobId: 'job-dead-explicit',
+          kind: 'ask',
+          status: 'completed',
+          submittedAt: '2026-03-14T00:00:00.000Z',
+          updatedAt: '2026-03-14T00:06:01.000Z',
+          retryCount: 0,
+        } as never);
+      vi.mocked(store.readJobResult).mockReturnValue({
+        event: {
+          content: 'should not be returned',
+          partial: false,
+          timestamp: '2026-03-14T00:06:01.000Z',
+        },
+      } as never);
+
+      const subCommands = jobsCommand.subCommands as unknown as {
+        wait?: RunnableCommand;
+      };
+      const waitCommand = subCommands.wait;
+      const run = waitCommand?.run;
+      if (waitCommand === undefined || run === undefined) {
+        throw new Error('jobsCommand.subCommands.wait.run is undefined');
+      }
+
+      const runPromise = Promise.resolve(run({
+        args: {
+          _: [],
+          jobId: 'job-dead-explicit',
+          poll: '1',
+          timeout: '0',
+          format: 'json',
+          quiet: false,
+          verbose: false,
+        } as never,
+        rawArgs: [],
+        cmd: waitCommand,
+      }));
+      await vi.advanceTimersByTimeAsync(250);
+      await runPromise;
+
+      expect(killSpy).toHaveBeenCalledWith(65432, 0);
+      expect(failStructuredMock).toHaveBeenCalledTimes(1);
+      const firstCall = failStructuredMock.mock.calls[0] as unknown as [
+        { category?: string; message?: string },
+        string,
+      ];
+      expect(firstCall[0].category).toBe('job_no_progress');
+      expect(firstCall[0].message).toContain('no progress');
+      expect(jsonRawMock).not.toHaveBeenCalled();
+    } finally {
+      killSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/tests/jobs-pid-utils.test.ts
+++ b/tests/jobs-pid-utils.test.ts
@@ -1,0 +1,76 @@
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { isWorkerPidAlive, latestJobProgressMs } from '../src/core/jobs/pid-utils.js';
+import type { JobRecord } from '../src/core/jobs/types.js';
+
+let testRoot: string;
+
+function makeJob(updatedAt: string, eventsPath: string): JobRecord {
+  return {
+    jobId: randomUUID(),
+    kind: 'ask',
+    status: 'running',
+    argv: ['ask', 'hello'],
+    submittedAt: updatedAt,
+    updatedAt,
+    retryCount: 0,
+    resultPath: join(testRoot, 'result.json'),
+    eventsPath,
+    errorPath: join(testRoot, 'error.json'),
+  };
+}
+
+describe('job pid utilities', () => {
+  beforeEach(() => {
+    testRoot = join(process.cwd(), `.tmp-jobs-pid-utils-${randomUUID()}`);
+    mkdirSync(testRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it('treats ESRCH as a dead worker pid', () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      const error = new Error('no such process') as NodeJS.ErrnoException;
+      error.code = 'ESRCH';
+      throw error;
+    });
+
+    expect(isWorkerPidAlive(12345)).toBe(false);
+    expect(killSpy).toHaveBeenCalledWith(12345, 0);
+  });
+
+  it('treats EPERM as an alive worker pid', () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      const error = new Error('permission denied') as NodeJS.ErrnoException;
+      error.code = 'EPERM';
+      throw error;
+    });
+
+    expect(isWorkerPidAlive(12345)).toBe(true);
+  });
+
+  it('preserves alive status for unexpected pid check errors', () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw new Error('unexpected pid check failure');
+    });
+
+    expect(isWorkerPidAlive(12345)).toBe(true);
+  });
+
+  it('uses the newest signal from job metadata and events file mtime', () => {
+    const eventsPath = join(testRoot, 'events.ndjson');
+    writeFileSync(eventsPath, '{"type":"chunk","timestamp":"2026-03-14T00:20:00.000Z"}\n');
+    const eventsTime = new Date('2026-03-14T00:20:00.000Z');
+    utimesSync(eventsPath, eventsTime, eventsTime);
+    const job = makeJob('2026-03-14T00:00:00.000Z', eventsPath);
+
+    expect(latestJobProgressMs(job)).toBe(statSync(eventsPath).mtimeMs);
+  });
+});

--- a/tests/jobs-runner.test.ts
+++ b/tests/jobs-runner.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { EventEmitter } from 'node:events';
-import { mkdirSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 
@@ -257,6 +257,7 @@ describe('job runner', () => {
   }, 10_000);
 
   it('keeps retrying runner lock acquisition when a live owner releases shortly after submit', async () => {
+    vi.useFakeTimers();
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
       return true;
     });
@@ -266,13 +267,16 @@ describe('job runner', () => {
     mkdirSync(cavendishDir, { recursive: true });
     writeFileSync(lockFile, '99999\n');
     setTimeout(() => {
-      unlinkSync(lockFile);
+      rmSync(lockFile, { force: true });
     }, 650);
 
     try {
-      await expect(runner.runJobRunner()).resolves.toBeUndefined();
+      const runPromise = runner.runJobRunner();
+      await vi.advanceTimersByTimeAsync(1_100);
+      await expect(runPromise).resolves.toBeUndefined();
     } finally {
       killSpy.mockRestore();
+      vi.useRealTimers();
     }
   }, 10_000);
 

--- a/tests/jobs-runner.test.ts
+++ b/tests/jobs-runner.test.ts
@@ -303,6 +303,10 @@ describe('job runner', () => {
 
   it('registers cleanup that marks the in-flight job failed when the runner receives SIGTERM', async () => {
     let cleanupCallback: (() => void | Promise<void>) | undefined;
+    let resolveCleanupRegistered: (() => void) | undefined;
+    const cleanupRegistered = new Promise<void>((resolve) => {
+      resolveCleanupRegistered = resolve;
+    });
     const finalLine = JSON.stringify({
       type: 'final',
       content: 'done',
@@ -315,6 +319,7 @@ describe('job runner', () => {
         vi.doMock('../src/core/shutdown.js', () => ({
           registerCleanup: (fn: () => void | Promise<void>): (() => void) => {
             cleanupCallback = fn;
+            resolveCleanupRegistered?.();
             return (): void => {
               cleanupCallback = undefined;
             };
@@ -328,9 +333,7 @@ describe('job runner', () => {
     });
 
     const runPromise = runner.runJobRunner();
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
+    await cleanupRegistered;
     expect(cleanupCallback).toBeDefined();
     await cleanupCallback?.();
     await runPromise;

--- a/tests/jobs-runner.test.ts
+++ b/tests/jobs-runner.test.ts
@@ -334,7 +334,14 @@ describe('job runner', () => {
     });
 
     const runPromise = runner.runJobRunner();
-    await cleanupRegistered;
+    await Promise.race([
+      cleanupRegistered,
+      new Promise<never>((_resolve, reject) => {
+        setTimeout(() => {
+          reject(new Error('cleanup registration timed out'));
+        }, 1_000);
+      }),
+    ]);
     expect(cleanupCallback).toBeDefined();
     await cleanupCallback?.();
     await runPromise;

--- a/tests/jobs-runner.test.ts
+++ b/tests/jobs-runner.test.ts
@@ -274,6 +274,7 @@ describe('job runner', () => {
       const runPromise = runner.runJobRunner();
       await vi.advanceTimersByTimeAsync(1_100);
       await expect(runPromise).resolves.toBeUndefined();
+      expect(killSpy).toHaveBeenCalledWith(99999, 0);
     } finally {
       killSpy.mockRestore();
       vi.useRealTimers();

--- a/tests/jobs-runner.test.ts
+++ b/tests/jobs-runner.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { EventEmitter } from 'node:events';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 
@@ -13,12 +13,14 @@ function makeChild(
   stdoutLines: string[],
   stderrLines: string[],
   exitCode: number,
-): EventEmitter & { stdout: PassThrough; stderr: PassThrough } {
+): EventEmitter & { pid: number; stdin: PassThrough; stdout: PassThrough; stderr: PassThrough } {
   const child = new EventEmitter() as EventEmitter & {
+    pid: number;
     stdin: PassThrough;
     stdout: PassThrough;
     stderr: PassThrough;
   };
+  child.pid = 12345;
   child.stdin = new PassThrough();
   child.stdout = new PassThrough();
   child.stderr = new PassThrough();
@@ -41,12 +43,14 @@ function makeDelayedChild(
   stderrLines: string[],
   exitCode: number,
   delayMs: number,
-): EventEmitter & { stdout: PassThrough; stderr: PassThrough } {
+): EventEmitter & { pid: number; stdin: PassThrough; stdout: PassThrough; stderr: PassThrough } {
   const child = new EventEmitter() as EventEmitter & {
+    pid: number;
     stdin: PassThrough;
     stdout: PassThrough;
     stderr: PassThrough;
   };
+  child.pid = 12345;
   child.stdin = new PassThrough();
   child.stdout = new PassThrough();
   child.stderr = new PassThrough();
@@ -66,6 +70,7 @@ function makeDelayedChild(
 
 async function importWithMocks(
   spawnImpl: () => ReturnType<typeof makeChild>,
+  beforeImport?: () => void,
 ): Promise<{
   runner: typeof import('../src/core/jobs/runner.js');
   store: typeof import('../src/core/jobs/store.js');
@@ -84,6 +89,7 @@ async function importWithMocks(
       spawn: spawnMock,
     };
   });
+  beforeImport?.();
   const runner = await import('../src/core/jobs/runner.js');
   const store = await import('../src/core/jobs/store.js');
   return { runner, store };
@@ -248,7 +254,27 @@ describe('job runner', () => {
     await expect(runner.runJobRunner()).rejects.toThrow(/could not acquire queue lock/);
 
     killSpy.mockRestore();
-  });
+  }, 10_000);
+
+  it('keeps retrying runner lock acquisition when a live owner releases shortly after submit', async () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      return true;
+    });
+    const { runner } = await importWithMocks(() => makeChild([], [], 0));
+    const cavendishDir = join(testRoot, '.cavendish');
+    const lockFile = join(cavendishDir, 'jobs-runner.lock');
+    mkdirSync(cavendishDir, { recursive: true });
+    writeFileSync(lockFile, '99999\n');
+    setTimeout(() => {
+      unlinkSync(lockFile);
+    }, 650);
+
+    try {
+      await expect(runner.runJobRunner()).resolves.toBeUndefined();
+    } finally {
+      killSpy.mockRestore();
+    }
+  }, 10_000);
 
   it('reuses the same in-process runner promise for concurrent calls', async () => {
     const finalLine = JSON.stringify({
@@ -269,5 +295,45 @@ describe('job runner', () => {
     ]);
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers cleanup that marks the in-flight job failed when the runner receives SIGTERM', async () => {
+    let cleanupCallback: (() => void | Promise<void>) | undefined;
+    const finalLine = JSON.stringify({
+      type: 'final',
+      content: 'done',
+      timestamp: '2026-03-14T00:00:00.000Z',
+      partial: false,
+    });
+    const { runner, store } = await importWithMocks(
+      () => makeDelayedChild([finalLine], [], 0, 100),
+      () => {
+        vi.doMock('../src/core/shutdown.js', () => ({
+          registerCleanup: (fn: () => void | Promise<void>): (() => void) => {
+            cleanupCallback = fn;
+            return (): void => {
+              cleanupCallback = undefined;
+            };
+          },
+        }));
+      },
+    );
+    const job = store.createJob({
+      kind: 'ask',
+      argv: ['ask', 'hello'],
+    });
+
+    const runPromise = runner.runJobRunner();
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    expect(cleanupCallback).toBeDefined();
+    await cleanupCallback?.();
+
+    const failedJob = store.readJob(job.jobId);
+    expect(failedJob?.status).toBe('failed');
+    expect(failedJob?.error?.category).toBe('runner_killed');
+    expect(failedJob?.workerPid).toBeUndefined();
+    await runPromise;
   });
 });

--- a/tests/jobs-runner.test.ts
+++ b/tests/jobs-runner.test.ts
@@ -334,14 +334,21 @@ describe('job runner', () => {
     });
 
     const runPromise = runner.runJobRunner();
-    await Promise.race([
-      cleanupRegistered,
-      new Promise<never>((_resolve, reject) => {
-        setTimeout(() => {
-          reject(new Error('cleanup registration timed out'));
-        }, 1_000);
-      }),
-    ]);
+    let cleanupTimeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        cleanupRegistered,
+        new Promise<never>((_resolve, reject) => {
+          cleanupTimeout = setTimeout(() => {
+            reject(new Error('cleanup registration timed out'));
+          }, 1_000);
+        }),
+      ]);
+    } finally {
+      if (cleanupTimeout !== undefined) {
+        clearTimeout(cleanupTimeout);
+      }
+    }
     expect(cleanupCallback).toBeDefined();
     await cleanupCallback?.();
     await runPromise;

--- a/tests/jobs-runner.test.ts
+++ b/tests/jobs-runner.test.ts
@@ -329,11 +329,11 @@ describe('job runner', () => {
     });
     expect(cleanupCallback).toBeDefined();
     await cleanupCallback?.();
+    await runPromise;
 
     const failedJob = store.readJob(job.jobId);
     expect(failedJob?.status).toBe('failed');
     expect(failedJob?.error?.category).toBe('runner_killed');
     expect(failedJob?.workerPid).toBeUndefined();
-    await runPromise;
   });
 });

--- a/tests/jobs-store.test.ts
+++ b/tests/jobs-store.test.ts
@@ -248,4 +248,51 @@ describe('job store', () => {
       nowSpy.mockRestore();
     }
   });
+
+  it('records terminal state and notification when stale running recovery reaches max retries', async () => {
+    const {
+      createJob,
+      getJobEventsPath,
+      getJobFilePath,
+      readJob,
+      readNextQueuedJob,
+      updateJob,
+    } = await importWithMockedHome();
+    const notifyFile = join(testRoot, 'notify.ndjson');
+    const job = createJob({
+      kind: 'ask',
+      argv: ['ask', 'hello'],
+      notifyFile,
+    });
+    const runningJob = updateJob(job.jobId, {
+      status: 'running',
+      retryCount: 3,
+    });
+    writeFileSync(getJobFilePath(job.jobId), `${JSON.stringify({
+      ...runningJob,
+      updatedAt: '2026-03-14T00:00:00.000Z',
+    }, null, 2)}\n`);
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(
+      new Date('2026-03-14T00:31:00.000Z').getTime(),
+    );
+
+    try {
+      expect(readNextQueuedJob()).toBeUndefined();
+
+      const failedJob = readJob(job.jobId);
+      expect(failedJob?.status).toBe('failed');
+      expect(failedJob?.error?.category).toBe('job_no_progress');
+      expect(readFileSync(getJobEventsPath(job.jobId), 'utf8')).toContain('"state":"job-failed"');
+      const notification = JSON.parse(readFileSync(notifyFile, 'utf8').trim()) as {
+        jobId?: string;
+        status?: string;
+        errorMessage?: string;
+      };
+      expect(notification.jobId).toBe(job.jobId);
+      expect(notification.status).toBe('failed');
+      expect(notification.errorMessage).toContain('did not make progress');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
 });

--- a/tests/jobs-store.test.ts
+++ b/tests/jobs-store.test.ts
@@ -187,6 +187,39 @@ describe('job store', () => {
     }
   });
 
+  it('does not recover a stale running job while its worker pid is still alive', async () => {
+    const { createJob, getJobFilePath, readJob, readNextQueuedJob, updateJob } = await importWithMockedHome();
+    const job = createJob({
+      kind: 'deep-research',
+      argv: ['deep-research', 'topic'],
+    });
+    const runningJob = updateJob(job.jobId, {
+      status: 'running',
+      workerPid: 12345,
+    });
+    writeFileSync(getJobFilePath(job.jobId), `${JSON.stringify({
+      ...runningJob,
+      updatedAt: '2026-03-14T00:00:00.000Z',
+    }, null, 2)}\n`);
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(
+      new Date('2026-03-14T00:31:00.000Z').getTime(),
+    );
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    try {
+      const next = readNextQueuedJob();
+
+      expect(next).toBeUndefined();
+      expect(killSpy).toHaveBeenCalledWith(12345, 0);
+      expect(readJob(job.jobId)?.status).toBe('running');
+      expect(readJob(job.jobId)?.retryCount).toBe(0);
+      expect(readJob(job.jobId)?.workerPid).toBe(12345);
+    } finally {
+      killSpy.mockRestore();
+      nowSpy.mockRestore();
+    }
+  });
+
   it('recovers a stale running job when updatedAt has not advanced', async () => {
     const { createJob, getJobFilePath, readNextQueuedJob, updateJob } = await importWithMockedHome();
     const job = createJob({

--- a/tests/jobs-store.test.ts
+++ b/tests/jobs-store.test.ts
@@ -156,4 +156,63 @@ describe('job store', () => {
 
     expect(readNextQueuedJob()?.jobId).toBe(job.jobId);
   });
+
+  it('recovers a stale running job whose worker pid is no longer alive', async () => {
+    const { createJob, readJob, readNextQueuedJob, updateJob } = await importWithMockedHome();
+    const job = createJob({
+      kind: 'ask',
+      argv: ['ask', 'hello'],
+    });
+    updateJob(job.jobId, {
+      status: 'running',
+      workerPid: 987_654,
+    });
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      const error = new Error('no such process') as NodeJS.ErrnoException;
+      error.code = 'ESRCH';
+      throw error;
+    });
+
+    try {
+      const next = readNextQueuedJob();
+
+      expect(next?.jobId).toBe(job.jobId);
+      expect(next?.status).toBe('queued');
+      expect(next?.retryCount).toBe(1);
+      expect(next?.workerPid).toBeUndefined();
+      expect(next?.lastRetryError).toContain('worker process 987654 is no longer running');
+      expect(readJob(job.jobId)?.status).toBe('queued');
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+
+  it('recovers a stale running job when updatedAt has not advanced', async () => {
+    const { createJob, getJobFilePath, readNextQueuedJob, updateJob } = await importWithMockedHome();
+    const job = createJob({
+      kind: 'ask',
+      argv: ['ask', 'hello'],
+    });
+    const runningJob = updateJob(job.jobId, {
+      status: 'running',
+    });
+    writeFileSync(getJobFilePath(job.jobId), `${JSON.stringify({
+      ...runningJob,
+      updatedAt: '2026-03-14T00:00:00.000Z',
+    }, null, 2)}\n`);
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(
+      new Date('2026-03-14T00:31:00.000Z').getTime(),
+    );
+
+    try {
+      const next = readNextQueuedJob();
+
+      expect(next?.jobId).toBe(job.jobId);
+      expect(next?.status).toBe('queued');
+      expect(next?.retryCount).toBe(1);
+      expect(next?.lastRetryError).toContain('no progress');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
 });

--- a/tests/jobs-store.test.ts
+++ b/tests/jobs-store.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -244,6 +244,35 @@ describe('job store', () => {
       expect(next?.status).toBe('queued');
       expect(next?.retryCount).toBe(1);
       expect(next?.lastRetryError).toContain('no progress');
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('does not recover a running job when events file mtime shows progress', async () => {
+    const { appendJobEvent, createJob, getJobEventsPath, getJobFilePath, readJob, readNextQueuedJob, updateJob } = await importWithMockedHome();
+    const job = createJob({
+      kind: 'deep-research',
+      argv: ['deep-research', 'topic'],
+    });
+    appendJobEvent(job.jobId, '{"type":"chunk","timestamp":"2026-03-14T00:30:00.000Z"}');
+    const eventsTime = new Date('2026-03-14T00:30:00.000Z');
+    utimesSync(getJobEventsPath(job.jobId), eventsTime, eventsTime);
+    const runningJob = updateJob(job.jobId, {
+      status: 'running',
+    });
+    writeFileSync(getJobFilePath(job.jobId), `${JSON.stringify({
+      ...runningJob,
+      updatedAt: '2026-03-14T00:00:00.000Z',
+    }, null, 2)}\n`);
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(
+      new Date('2026-03-14T00:31:00.000Z').getTime(),
+    );
+
+    try {
+      expect(readNextQueuedJob()).toBeUndefined();
+      expect(readJob(job.jobId)?.status).toBe('running');
+      expect(readJob(job.jobId)?.retryCount).toBe(0);
     } finally {
       nowSpy.mockRestore();
     }

--- a/tests/jobs-worker.test.ts
+++ b/tests/jobs-worker.test.ts
@@ -422,6 +422,30 @@ describe('job worker', () => {
     expect(store.readJobError(job.jobId)?.message).toContain('ERR_MODULE_NOT_FOUND');
   });
 
+  it('caps captured stderr in fallback error details', async () => {
+    const stderrLines = Array.from({ length: 500 }, (_unused, index) => `stderr line ${String(index).padStart(3, '0')}`);
+    const { store, worker } = await importWithMocks(() => makeChild([], stderrLines, 1));
+    const job = store.createJob({
+      kind: 'ask',
+      argv: ['ask', 'hello'],
+    });
+
+    const result = await worker.runJobWorker(job.jobId);
+
+    expect(result.outcome).toBe('failed');
+    const message = store.readJobError(job.jobId)?.message;
+    if (message === undefined) {
+      throw new Error('job error message was not recorded');
+    }
+    expect(message).toContain('[stderr truncated');
+    expect(message).toContain('stderr line 499');
+    expect(message).not.toContain('stderr line 000');
+    const retainedLineCount = message
+      .split('\n')
+      .filter((line) => line.startsWith('stderr line')).length;
+    expect(retainedLineCount).toBeLessThanOrEqual(100);
+  });
+
   it('surfaces child stdin EPIPE as a structured job error without throwing', async () => {
     const { store, worker } = await importWithMocks(() => makeChildWithStdinError('EPIPE', 0));
     const job = store.createJob({

--- a/tests/jobs-worker.test.ts
+++ b/tests/jobs-worker.test.ts
@@ -435,5 +435,7 @@ describe('job worker', () => {
     });
     expect(store.readJobError(job.jobId)?.message).toContain('stdin closed before the prompt could be delivered');
     expect(store.readJob(job.jobId)?.status).toBe('failed');
+    expect(store.readJob(job.jobId)?.exitCode).toBe(store.readJobError(job.jobId)?.exitCode);
+    expect(store.readJob(job.jobId)?.exitCode).toBeGreaterThan(0);
   });
 });

--- a/tests/jobs-worker.test.ts
+++ b/tests/jobs-worker.test.ts
@@ -290,10 +290,39 @@ describe('job worker', () => {
 
     try {
       await worker.runJobWorkerOrExit(job.jobId);
+      expect(store.readJobError(job.jobId)?.exitCode).toBe(1);
+      expect(store.readJob(job.jobId)?.exitCode).toBe(1);
       expect(process.exitCode).toBe(1);
     } finally {
       process.exitCode = previousExitCode;
     }
+  });
+
+  it('does not overwrite terminal job errors with runner_killed', async () => {
+    const { store, worker } = await importWithMocks(() => makeChild([], [], 0));
+    const job = store.createJob({
+      kind: 'ask',
+      argv: ['ask', 'hello'],
+    });
+    const originalError = {
+      error: true as const,
+      category: 'timeout' as const,
+      message: 'already timed out',
+      exitCode: 7,
+      action: 'retry',
+    };
+    store.writeJobError(job.jobId, originalError);
+    store.updateJob(job.jobId, {
+      status: 'timed_out',
+      error: originalError,
+      exitCode: 7,
+    });
+
+    worker.markJobRunnerKilled(job.jobId);
+
+    expect(store.readJob(job.jobId)?.status).toBe('timed_out');
+    expect(store.readJob(job.jobId)?.error?.category).toBe('timeout');
+    expect(store.readJobError(job.jobId)?.category).toBe('timeout');
   });
 
   it('records fallback errors even when job metadata becomes unreadable', async () => {

--- a/tests/jobs-worker.test.ts
+++ b/tests/jobs-worker.test.ts
@@ -12,12 +12,14 @@ function makeChild(
   stdoutLines: string[],
   stderrLines: string[],
   exitCode: number,
-): EventEmitter & { stdin: PassThrough; stdout: PassThrough; stderr: PassThrough } {
+): EventEmitter & { pid: number; stdin: PassThrough; stdout: PassThrough; stderr: PassThrough } {
   const child = new EventEmitter() as EventEmitter & {
+    pid: number;
     stdin: PassThrough;
     stdout: PassThrough;
     stderr: PassThrough;
   };
+  child.pid = 12345;
   child.stdin = new PassThrough();
   child.stdout = new PassThrough();
   child.stderr = new PassThrough();
@@ -29,6 +31,31 @@ function makeChild(
     for (const line of stderrLines) {
       child.stderr.write(`${line}\n`);
     }
+    child.stderr.end();
+    child.emit('close', exitCode);
+  });
+  return child;
+}
+
+function makeChildWithStdinError(
+  errorCode: string,
+  exitCode: number,
+): EventEmitter & { pid: number; stdin: PassThrough; stdout: PassThrough; stderr: PassThrough } {
+  const child = new EventEmitter() as EventEmitter & {
+    pid: number;
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+  };
+  child.pid = 12345;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  queueMicrotask(() => {
+    const error = new Error(`write ${errorCode}`) as NodeJS.ErrnoException;
+    error.code = errorCode;
+    child.stdin.emit('error', error);
+    child.stdout.end();
     child.stderr.end();
     child.emit('close', exitCode);
   });
@@ -91,6 +118,7 @@ describe('job worker', () => {
 
     expect(result.outcome).toBe('completed');
     expect(store.readJob(job.jobId)?.status).toBe('completed');
+    expect(store.readJob(job.jobId)?.workerPid).toBeUndefined();
     expect(store.readJobResult(job.jobId)?.event.content).toBe('done');
     expect(readFileSync(notifyFile, 'utf8')).toContain('"jobId"');
   });
@@ -115,6 +143,7 @@ describe('job worker', () => {
     expect(result.record?.retryCount).toBe(1);
     expect(store.readJob(job.jobId)?.status).toBe('queued');
     expect(store.readJob(job.jobId)?.startedAt).toBeUndefined();
+    expect(store.readJob(job.jobId)?.workerPid).toBeUndefined();
     expect(store.readJob(job.jobId)?.retryCount).toBe(1);
     expect(store.readJob(job.jobId)?.lastRetriedAt).toBeDefined();
     expect(store.readJob(job.jobId)?.lastRetryError).toContain('Another cavendish process');
@@ -318,5 +347,93 @@ describe('job worker', () => {
     expect(spawnArgs).toContain('--quiet');
     // Prompt must be piped via stdin from the prompt file
     expect(capturedStdinData).toBe('my prompt from file');
+  });
+
+  it('records child worker pid while the child process is running', async () => {
+    const finalLine = JSON.stringify({
+      type: 'final',
+      content: 'done',
+      timestamp: '2026-03-14T00:00:00.000Z',
+      partial: false,
+    });
+    let observedWorkerPid: number | undefined;
+    const { store, worker } = await importWithMocks(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        pid: number;
+        stdin: PassThrough;
+        stdout: PassThrough;
+        stderr: PassThrough;
+      };
+      child.pid = 12345;
+      child.stdin = new PassThrough();
+      child.stdout = new PassThrough();
+      child.stderr = new PassThrough();
+      child.stdin.on('finish', () => {
+        const jobs = store.listJobs();
+        observedWorkerPid = jobs[0]?.workerPid;
+      });
+      setTimeout(() => {
+        child.stdout.write(`${finalLine}\n`);
+        child.stdout.end();
+        child.stderr.end();
+        child.emit('close', 0);
+      }, 0);
+      return child;
+    });
+    const job = store.createJob({
+      kind: 'ask',
+      argv: ['ask', 'hello'],
+    });
+
+    await worker.runJobWorker(job.jobId);
+
+    expect(observedWorkerPid).toBe(12345);
+    expect(store.readJob(job.jobId)?.workerPid).toBeUndefined();
+  });
+
+  it('records non-JSON stderr lines in events and fallback error details', async () => {
+    const { store, worker } = await importWithMocks(() => makeChild([], [
+      'node:internal/modules/esm/resolve: boom',
+      'Error [ERR_MODULE_NOT_FOUND]: Cannot find package',
+    ], 1));
+    const job = store.createJob({
+      kind: 'ask',
+      argv: ['ask', 'hello'],
+    });
+
+    const result = await worker.runJobWorker(job.jobId);
+
+    expect(result.outcome).toBe('failed');
+    const events = readFileSync(store.getJobEventsPath(job.jobId), 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { type?: string; line?: string });
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: 'stderr',
+        line: 'node:internal/modules/esm/resolve: boom',
+      }),
+      expect.objectContaining({
+        type: 'stderr',
+        line: 'Error [ERR_MODULE_NOT_FOUND]: Cannot find package',
+      }),
+    ]));
+    expect(store.readJobError(job.jobId)?.message).toContain('Detached worker stderr:');
+    expect(store.readJobError(job.jobId)?.message).toContain('ERR_MODULE_NOT_FOUND');
+  });
+
+  it('surfaces child stdin EPIPE as a structured job error without throwing', async () => {
+    const { store, worker } = await importWithMocks(() => makeChildWithStdinError('EPIPE', 0));
+    const job = store.createJob({
+      kind: 'ask',
+      argv: ['ask', 'hello'],
+      prompt: 'x'.repeat(1024 * 1024),
+    });
+
+    await expect(worker.runJobWorker(job.jobId)).resolves.toMatchObject({
+      outcome: 'failed',
+    });
+    expect(store.readJobError(job.jobId)?.message).toContain('stdin closed before the prompt could be delivered');
+    expect(store.readJob(job.jobId)?.status).toBe('failed');
   });
 });

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -61,6 +61,29 @@ describe('validateAllSelectors', () => {
       count: 1,
     }));
   });
+
+  it('does not count Deep Research selector matches from the outer page', async () => {
+    const page = {
+      locator: (selector: string) => ({
+        count: () => Promise.resolve(selector === 'main' ? 1 : 0),
+      }),
+      frames: () => [
+        {
+          url: () => 'https://chatgpt.com/app/deep_research/session',
+          locator: () => ({
+            count: () => Promise.resolve(0),
+          }),
+        },
+      ],
+    };
+
+    const results = await validateAllSelectors(page as unknown as Parameters<typeof validateAllSelectors>[0], true);
+    const deepResearchReportRoot = results.find((result) => result.name === 'DEEP_RESEARCH_REPORT_ROOT');
+
+    expect(deepResearchReportRoot).toEqual(expect.objectContaining({
+      count: 0,
+    }));
+  });
 });
 
 // ── compareWithBaseline ───────────────────────────────────

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -10,6 +10,7 @@ import {
   compareWithBaseline,
   determineBroken,
   formatReportText,
+  validateAllSelectors,
 } from '../src/core/report.js';
 
 // ── categorizeSelector ────────────────────────────────────
@@ -34,6 +35,31 @@ describe('categorizeSelector', () => {
 
   it('defaults unknown names to contextual', () => {
     expect(categorizeSelector('NONEXISTENT_SELECTOR')).toBe('contextual');
+  });
+});
+
+describe('validateAllSelectors', () => {
+  it('counts Deep Research selectors inside the matching iframe', async () => {
+    const page = {
+      locator: () => ({
+        count: () => Promise.resolve(0),
+      }),
+      frames: () => [
+        {
+          url: () => 'https://chatgpt.com/app/deep_research/session',
+          locator: (selector: string) => ({
+            count: () => Promise.resolve(selector === '.deep-research-app' ? 1 : 0),
+          }),
+        },
+      ],
+    };
+
+    const results = await validateAllSelectors(page as unknown as Parameters<typeof validateAllSelectors>[0], true);
+    const deepResearchApp = results.find((result) => result.name === 'DEEP_RESEARCH_APP');
+
+    expect(deepResearchApp).toEqual(expect.objectContaining({
+      count: 1,
+    }));
   });
 });
 

--- a/tests/response-handler.test.ts
+++ b/tests/response-handler.test.ts
@@ -214,6 +214,31 @@ describe('waitForResponse()', () => {
     );
   });
 
+  it('classifies stop-button probe browser closure as browser disconnected', async () => {
+    const { waitForResponse } = await import('../src/core/driver/response-handler.js');
+    const page = {
+      locator(selector: string) {
+        if (selector === SELECTORS.STOP_BUTTON) {
+          return {
+            isVisible: () => Promise.reject(new Error('Target page, context or browser has been closed')),
+          };
+        }
+        if (selector === SELECTORS.ASSISTANT_MESSAGE) {
+          return {
+            count: () => Promise.resolve(0),
+          };
+        }
+        throw new Error(`Unexpected selector: ${selector}`);
+      },
+    } as unknown as Parameters<typeof waitForResponse>[0];
+
+    await expect(waitForResponse(page, {
+      timeout: 5_000,
+      initialMsgCount: 0,
+      quiet: true,
+    })).rejects.toHaveProperty('category', 'browser_disconnected');
+  });
+
   it('does not stall when thinking text changes despite no assistant message output (#194)', async () => {
     const { waitForResponse } = await import('../src/core/driver/response-handler.js');
     const now = vi.spyOn(Date, 'now');

--- a/tests/submit-detached-job.test.ts
+++ b/tests/submit-detached-job.test.ts
@@ -4,7 +4,10 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const NOTIFY_FILE = '/Users/sankenbisha/Dev/cavendish/.tmp-tests/notify.ndjson';
+const NOTIFY_FILE = join(process.cwd(), '.tmp-tests', 'notify.ndjson');
+const SUBMIT_RESULT_PATH = join(process.cwd(), '.tmp-tests', 'submit-result.json');
+const SUBMIT_EVENTS_PATH = join(process.cwd(), '.tmp-tests', 'submit-events.ndjson');
+const SUBMIT_ERROR_PATH = join(process.cwd(), '.tmp-tests', 'submit-error.json');
 
 let spawnMock: ReturnType<typeof vi.fn>;
 let createJobMock: ReturnType<typeof vi.fn>;
@@ -42,9 +45,9 @@ vi.mock('../src/core/jobs/store.js', () => {
     submittedAt: '2026-03-14T00:00:00.000Z',
     updatedAt: '2026-03-14T00:00:00.000Z',
     retryCount: 0,
-    resultPath: '/Users/sankenbisha/Dev/cavendish/.tmp-tests/submit-result.json',
-    eventsPath: '/Users/sankenbisha/Dev/cavendish/.tmp-tests/submit-events.ndjson',
-    errorPath: '/Users/sankenbisha/Dev/cavendish/.tmp-tests/submit-error.json',
+    resultPath: SUBMIT_RESULT_PATH,
+    eventsPath: SUBMIT_EVENTS_PATH,
+    errorPath: SUBMIT_ERROR_PATH,
   }));
   updateJobMock = vi.fn();
   writeJobErrorMock = vi.fn();
@@ -158,9 +161,9 @@ describe('submitDetachedJob', () => {
       submittedAt: '2026-03-14T00:00:00.000Z',
       updatedAt: '2026-03-14T00:00:00.000Z',
       retryCount: 0,
-      resultPath: '/Users/sankenbisha/Dev/cavendish/.tmp-tests/submit-result.json',
-      eventsPath: '/Users/sankenbisha/Dev/cavendish/.tmp-tests/submit-events.ndjson',
-      errorPath: '/Users/sankenbisha/Dev/cavendish/.tmp-tests/submit-error.json',
+      resultPath: SUBMIT_RESULT_PATH,
+      eventsPath: SUBMIT_EVENTS_PATH,
+      errorPath: SUBMIT_ERROR_PATH,
     });
     try {
       const { submitDetachedJob } = await import('../src/core/jobs/submit.js');

--- a/tests/submit-detached-job.test.ts
+++ b/tests/submit-detached-job.test.ts
@@ -149,11 +149,18 @@ describe('submitDetachedJob', () => {
       });
       return child;
     });
-    readJobMock.mockReturnValue({
+    readJobMock.mockReturnValueOnce({
       jobId: 'job-123',
       kind: 'ask',
       status: 'failed',
       exitCode: 1,
+      argv: [],
+      submittedAt: '2026-03-14T00:00:00.000Z',
+      updatedAt: '2026-03-14T00:00:00.000Z',
+      retryCount: 0,
+      resultPath: '/Users/sankenbisha/Dev/cavendish/.tmp-tests/submit-result.json',
+      eventsPath: '/Users/sankenbisha/Dev/cavendish/.tmp-tests/submit-events.ndjson',
+      errorPath: '/Users/sankenbisha/Dev/cavendish/.tmp-tests/submit-error.json',
     });
     try {
       const { submitDetachedJob } = await import('../src/core/jobs/submit.js');
@@ -196,7 +203,10 @@ describe('submitDetachedJob', () => {
       await vi.advanceTimersByTimeAsync(501);
       await submitPromise;
 
-      spawnedChild?.emit('exit', 1, null);
+      if (spawnedChild === undefined) {
+        throw new Error('Expected detached child process to be captured');
+      }
+      spawnedChild.emit('exit', 1, null);
 
       expect(writeJobErrorMock).not.toHaveBeenCalled();
       expect(updateJobMock).not.toHaveBeenCalled();

--- a/tests/submit-detached-job.test.ts
+++ b/tests/submit-detached-job.test.ts
@@ -14,6 +14,7 @@ let updateJobMock: ReturnType<typeof vi.fn>;
 let writeJobErrorMock: ReturnType<typeof vi.fn>;
 let testRoot: string;
 let cliEntry: string;
+let spawnedChild: ReturnType<typeof makeSpawnChild> | undefined;
 
 function makeSpawnChild(): EventEmitter & { unref: ReturnType<typeof vi.fn> } {
   const child = new EventEmitter() as EventEmitter & { unref: ReturnType<typeof vi.fn> };
@@ -56,6 +57,7 @@ vi.mock('../src/core/jobs/store.js', () => {
 describe('submitDetachedJob', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    spawnedChild = undefined;
     testRoot = mkdtempSync(join(process.cwd(), '.tmp-submit-'));
     cliEntry = join(testRoot, 'index.mjs');
     writeFileSync(cliEntry, '');
@@ -166,6 +168,33 @@ describe('submitDetachedJob', () => {
       }));
       expect(readJobMock).toHaveBeenCalledWith('job-123');
     } finally {
+      process.argv[1] = previousArgv1;
+    }
+  });
+
+  it('stops observing runner exits after the startup window', async () => {
+    vi.useFakeTimers();
+    const previousArgv1 = process.argv[1];
+    process.argv[1] = cliEntry;
+    spawnMock.mockImplementationOnce(() => {
+      spawnedChild = makeSpawnChild();
+      return spawnedChild;
+    });
+    try {
+      const { submitDetachedJob } = await import('../src/core/jobs/submit.js');
+      const submitPromise = submitDetachedJob({
+        kind: 'ask',
+        argv: ['ask', 'hello'],
+      });
+      await vi.advanceTimersByTimeAsync(501);
+      await submitPromise;
+
+      spawnedChild?.emit('exit', 1, null);
+
+      expect(writeJobErrorMock).not.toHaveBeenCalled();
+      expect(updateJobMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
       process.argv[1] = previousArgv1;
     }
   });

--- a/tests/submit-detached-job.test.ts
+++ b/tests/submit-detached-job.test.ts
@@ -180,6 +180,13 @@ describe('submitDetachedJob', () => {
       kind: 'ask',
       status: 'failed',
       exitCode: 1,
+      error: {
+        error: true,
+        category: 'unknown',
+        message: 'Detached runner exited during startup (code: 1, signal: null)',
+        exitCode: 1,
+        action: 'Fix the detached runner launch failure and retry the command.',
+      },
       argv: [],
       submittedAt: '2026-03-14T00:00:00.000Z',
       updatedAt: '2026-03-14T00:00:00.000Z',
@@ -201,6 +208,10 @@ describe('submitDetachedJob', () => {
         status: 'failed',
         exitCode: 1,
       });
+      expect(record.error?.category).toBe('unknown');
+      expect(record.error?.exitCode).toBe(1);
+      expect(record.error?.action).toBe('Fix the detached runner launch failure and retry the command.');
+      expect(record.error?.message).toContain('Detached runner exited during startup');
       expect(writeJobErrorMock).toHaveBeenCalledOnce();
       const writeCall = writeJobErrorMock.mock.calls[0] as [string, StructuredErrorPayload] | undefined;
       expect(writeCall?.[0]).toBe('job-123');

--- a/tests/submit-detached-job.test.ts
+++ b/tests/submit-detached-job.test.ts
@@ -38,6 +38,13 @@ vi.mock('../src/core/jobs/store.js', () => {
     jobId: 'job-123',
     kind: 'ask',
     status: 'queued',
+    argv: [],
+    submittedAt: '2026-03-14T00:00:00.000Z',
+    updatedAt: '2026-03-14T00:00:00.000Z',
+    retryCount: 0,
+    resultPath: '/Users/sankenbisha/Dev/cavendish/.tmp-tests/submit-result.json',
+    eventsPath: '/Users/sankenbisha/Dev/cavendish/.tmp-tests/submit-events.ndjson',
+    errorPath: '/Users/sankenbisha/Dev/cavendish/.tmp-tests/submit-error.json',
   }));
   updateJobMock = vi.fn();
   writeJobErrorMock = vi.fn();

--- a/tests/submit-detached-job.test.ts
+++ b/tests/submit-detached-job.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -13,12 +14,18 @@ let writeJobErrorMock: ReturnType<typeof vi.fn>;
 let testRoot: string;
 let cliEntry: string;
 
+function makeSpawnChild(): EventEmitter & { unref: ReturnType<typeof vi.fn> } {
+  const child = new EventEmitter() as EventEmitter & { unref: ReturnType<typeof vi.fn> };
+  child.unref = unrefMock;
+  queueMicrotask(() => {
+    child.emit('spawn');
+  });
+  return child;
+}
+
 vi.mock('node:child_process', () => {
   unrefMock = vi.fn();
-  spawnMock = vi.fn(() => ({
-    once: vi.fn(),
-    unref: unrefMock,
-  }));
+  spawnMock = vi.fn(() => makeSpawnChild());
   return {
     spawn: spawnMock,
   };
@@ -56,7 +63,7 @@ describe('submitDetachedJob', () => {
     process.argv[1] = cliEntry;
     try {
       const { submitDetachedJob } = await import('../src/core/jobs/submit.js');
-      const record: { jobId: string; kind: string } = submitDetachedJob({
+      const record: { jobId: string; kind: string } = await submitDetachedJob({
         kind: 'ask',
         argv: ['ask', 'hello'],
         prompt: 'hello from stdin',
@@ -101,11 +108,40 @@ describe('submitDetachedJob', () => {
     });
     try {
       const { submitDetachedJob } = await import('../src/core/jobs/submit.js');
-      expect(() => submitDetachedJob({
+      await expect(submitDetachedJob({
         kind: 'ask',
         argv: ['ask', 'hello'],
-      })).toThrow('spawn failed');
+      })).rejects.toThrow('spawn failed');
 
+      expect(writeJobErrorMock).toHaveBeenCalledOnce();
+      expect(updateJobMock).toHaveBeenCalledWith('job-123', expect.objectContaining({
+        status: 'failed',
+        exitCode: 1,
+      }));
+    } finally {
+      process.argv[1] = previousArgv1;
+    }
+  });
+
+  it('marks the job failed when the detached runner exits non-zero immediately after spawn', async () => {
+    const previousArgv1 = process.argv[1];
+    process.argv[1] = cliEntry;
+    spawnMock.mockImplementationOnce(() => {
+      const child = makeSpawnChild();
+      queueMicrotask(() => {
+        child.emit('exit', 1, null);
+      });
+      return child;
+    });
+    try {
+      const { submitDetachedJob } = await import('../src/core/jobs/submit.js');
+
+      const record = await submitDetachedJob({
+        kind: 'ask',
+        argv: ['ask', 'hello'],
+      });
+
+      expect(record.jobId).toBe('job-123');
       expect(writeJobErrorMock).toHaveBeenCalledOnce();
       expect(updateJobMock).toHaveBeenCalledWith('job-123', expect.objectContaining({
         status: 'failed',

--- a/tests/submit-detached-job.test.ts
+++ b/tests/submit-detached-job.test.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { StructuredErrorPayload } from '../src/core/errors.js';
+
 const NOTIFY_FILE = join(process.cwd(), '.tmp-tests', 'notify.ndjson');
 const SUBMIT_RESULT_PATH = join(process.cwd(), '.tmp-tests', 'submit-result.json');
 const SUBMIT_EVENTS_PATH = join(process.cwd(), '.tmp-tests', 'submit-events.ndjson');
@@ -18,6 +20,12 @@ let writeJobErrorMock: ReturnType<typeof vi.fn>;
 let testRoot: string;
 let cliEntry: string;
 let spawnedChild: ReturnType<typeof makeSpawnChild> | undefined;
+
+interface FailedJobUpdate {
+  status?: string;
+  exitCode?: number;
+  error?: StructuredErrorPayload;
+}
 
 function makeSpawnChild(): EventEmitter & { unref: ReturnType<typeof vi.fn> } {
   const child = new EventEmitter() as EventEmitter & { unref: ReturnType<typeof vi.fn> };
@@ -133,10 +141,25 @@ describe('submitDetachedJob', () => {
       })).rejects.toThrow('spawn failed');
 
       expect(writeJobErrorMock).toHaveBeenCalledOnce();
-      expect(updateJobMock).toHaveBeenCalledWith('job-123', expect.objectContaining({
-        status: 'failed',
+      const writeCall = writeJobErrorMock.mock.calls[0] as [string, StructuredErrorPayload] | undefined;
+      expect(writeCall?.[0]).toBe('job-123');
+      expect(writeCall?.[1]).toMatchObject({
+        error: true,
+        category: 'unknown',
+        message: 'spawn failed',
         exitCode: 1,
-      }));
+        action: 'Fix the detached runner launch failure and retry the command.',
+      });
+      const updateCall = updateJobMock.mock.calls[0] as [string, FailedJobUpdate] | undefined;
+      expect(updateCall?.[0]).toBe('job-123');
+      expect(updateCall?.[1].status).toBe('failed');
+      expect(updateCall?.[1].exitCode).toBe(1);
+      expect(updateCall?.[1].error).toMatchObject({
+        category: 'unknown',
+        message: 'spawn failed',
+        exitCode: 1,
+        action: 'Fix the detached runner launch failure and retry the command.',
+      });
     } finally {
       process.argv[1] = previousArgv1;
     }
@@ -179,10 +202,25 @@ describe('submitDetachedJob', () => {
         exitCode: 1,
       });
       expect(writeJobErrorMock).toHaveBeenCalledOnce();
-      expect(updateJobMock).toHaveBeenCalledWith('job-123', expect.objectContaining({
-        status: 'failed',
+      const writeCall = writeJobErrorMock.mock.calls[0] as [string, StructuredErrorPayload] | undefined;
+      expect(writeCall?.[0]).toBe('job-123');
+      expect(writeCall?.[1]).toMatchObject({
+        error: true,
+        category: 'unknown',
         exitCode: 1,
-      }));
+        action: 'Fix the detached runner launch failure and retry the command.',
+      });
+      expect(writeCall?.[1].message).toContain('Detached runner exited during startup');
+      const updateCall = updateJobMock.mock.calls[0] as [string, FailedJobUpdate] | undefined;
+      expect(updateCall?.[0]).toBe('job-123');
+      expect(updateCall?.[1].status).toBe('failed');
+      expect(updateCall?.[1].exitCode).toBe(1);
+      expect(updateCall?.[1].error).toMatchObject({
+        category: 'unknown',
+        exitCode: 1,
+        action: 'Fix the detached runner launch failure and retry the command.',
+      });
+      expect(updateCall?.[1].error?.message).toContain('Detached runner exited during startup');
       expect(readJobMock).toHaveBeenCalledWith('job-123');
     } finally {
       process.argv[1] = previousArgv1;

--- a/tests/submit-detached-job.test.ts
+++ b/tests/submit-detached-job.test.ts
@@ -8,6 +8,7 @@ const NOTIFY_FILE = '/Users/sankenbisha/Dev/cavendish/.tmp-tests/notify.ndjson';
 
 let spawnMock: ReturnType<typeof vi.fn>;
 let createJobMock: ReturnType<typeof vi.fn>;
+let readJobMock: ReturnType<typeof vi.fn>;
 let unrefMock: ReturnType<typeof vi.fn>;
 let updateJobMock: ReturnType<typeof vi.fn>;
 let writeJobErrorMock: ReturnType<typeof vi.fn>;
@@ -32,6 +33,11 @@ vi.mock('node:child_process', () => {
 });
 
 vi.mock('../src/core/jobs/store.js', () => {
+  readJobMock = vi.fn(() => ({
+    jobId: 'job-123',
+    kind: 'ask',
+    status: 'queued',
+  }));
   updateJobMock = vi.fn();
   writeJobErrorMock = vi.fn();
   createJobMock = vi.fn(() => ({
@@ -41,6 +47,7 @@ vi.mock('../src/core/jobs/store.js', () => {
   }));
   return {
     createJob: createJobMock,
+    readJob: readJobMock,
     updateJob: updateJobMock,
     writeJobError: writeJobErrorMock,
   };
@@ -133,6 +140,12 @@ describe('submitDetachedJob', () => {
       });
       return child;
     });
+    readJobMock.mockReturnValue({
+      jobId: 'job-123',
+      kind: 'ask',
+      status: 'failed',
+      exitCode: 1,
+    });
     try {
       const { submitDetachedJob } = await import('../src/core/jobs/submit.js');
 
@@ -141,12 +154,17 @@ describe('submitDetachedJob', () => {
         argv: ['ask', 'hello'],
       });
 
-      expect(record.jobId).toBe('job-123');
+      expect(record).toMatchObject({
+        jobId: 'job-123',
+        status: 'failed',
+        exitCode: 1,
+      });
       expect(writeJobErrorMock).toHaveBeenCalledOnce();
       expect(updateJobMock).toHaveBeenCalledWith('job-123', expect.objectContaining({
         status: 'failed',
         exitCode: 1,
       }));
+      expect(readJobMock).toHaveBeenCalledWith('job-123');
     } finally {
       process.argv[1] = previousArgv1;
     }


### PR DESCRIPTION
## Summary

- Closes #227 (detached job lifecycle robustness), #228 (error classification / visibility), #229 (report coverage).
- 11 commits total: 8 fix/test commits + 3 simplify-pass commits (shared helpers, stderr cap, exit-code constants).
- Test count: 412 → 438 (+26 tests, covering every new behavior via TDD).

## Issues addressed

### #227 — detached job lifecycle
- `workerPid` persisted per job (new field on `JobRecord`), set on spawn, cleared on terminal transitions.
- Stale `running` job recovery: a dead/missing worker PID now triggers retry-or-fail; a live PID is always respected so the recovery never double-executes a still-running worker.
- `jobs wait` now has progress-stall detection using `max(job.updatedAt, events.ndjson mtime)` combined with PID liveness, consistent between `wait` and `store` paths.
- `child.stdin` EPIPE is caught and surfaced as a structured error instead of crashing the runner. Exit code is normalized so `job.exitCode` matches `error.exitCode`.
- Runner registers a cleanup callback that marks in-flight jobs as `runner_killed` on SIGTERM before `process.exit(143)`.
- Runner lock retry budget raised to ~5s so a submit arriving during a previous runner's release boundary still wins the lock.
- `submitDetachedJob` observes the spawned runner briefly after `spawn` and records an immediate failed status if the runner exits non-zero within 500 ms; returns the re-read record so callers cannot see `status: queued` when the job is already `failed`.

### #228 — error classification / visibility
- New `browser_disconnected` error category, classified before selector/timeout classifiers when the Playwright message matches "Target page, context or browser has been closed" or "Target closed". User `action` is now "Chrome was closed or crashed. Restart Chrome and re-run the command."
- `response-handler.ts` stop-button inspection no longer wraps CDP-disconnect errors as `selector_miss`.
- Worker child's non-JSON stderr is now appended to `events.ndjson` as `{ type: 'stderr', line, timestamp }` AND included in the fallback `error.json.message` when no structured error is parsed. Capture is bounded: last 100 lines or 16 KiB, whichever comes first, with an explicit truncation marker.

### #229 — report coverage
- `cavendish report` now traverses `page.frames()` matching `SELECTORS.DEEP_RESEARCH_FRAME_URL` when counting DR selectors — so DR iframe content is no longer invisible to the drift detector when a DR page is active.
- `cavendish doctor`'s Google Drive check now actually opens the composer's + menu and verifies the "Google Drive から追加する" entry instead of always returning `skip`.

## Simplify pass (after Codex review approval)

- `src/core/jobs/pid-utils.ts`: shared `isErrnoException` + `isWorkerPidAlive` (polarity unified; ESRCH → dead, EPERM/unknown → alive); `latestJobProgressMs()` used by both `jobs wait` and store recovery so both paths see the same progress signal.
- Worker stderr capture bounded with ring-buffer semantics + truncation marker.
- `runner_killed` (11) and `job_no_progress` (12) exit-code literals replaced with `EXIT_CODES` constants.

## Scope check

| Area | Touched? | Behavior change? |
|---|---|---|
| `ask` synchronous path | No | None |
| `ask --detach` submit + runner handoff | Yes | Fails fast on immediate spawn failure; same stdout shape on success |
| `jobs wait` | Yes | Now detects stale dead workers; live workers continue unaffected; same stdout on success |
| Chrome disconnect error flow | Yes | Category / action changed; existing tests updated |
| Deep Research | No | Selectors unchanged; only `report` iframe traversal is new |
| `doctor` / `report` | Yes | Additional live checks; JSON schema unchanged |

## Verification

- `npm run lint`: exit 0
- `npm run typecheck`: exit 0
- `npm test`: 48 files, 438 passed
- `npm run deadcode`: exit 0
- Live Chrome test: `cavendish doctor --json` (7 pass / 0 fail), `cavendish report --format json` (0 broken against baseline), end-to-end `cavendish ask --detach "Reply with exactly the three characters: OK." → cavendish jobs wait <id> --poll 30` completed correctly with `workerPid` populated during `running` and cleared at `completed`. Test conversation deleted post-verification.
- Codex review: 5 rounds (multi-agent) until approved with no outstanding findings.
- Simplify pass: 3 parallel reviewers (reuse / quality / efficiency) agreed on 6 findings; all applied in 3 focused refactor commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/cavendish/pull/230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track worker PIDs for jobs and verify Google Drive composer interaction.

* **Bug Fixes**
  * Detect and fail stalled running jobs with clearer restart guidance.
  * Surface browser/disconnect errors instead of masking them.

* **Improvements**
  * More robust detached-job startup and async handling; improved stderr diagnostics.
  * Record runner-killed failures and reliably clear transient job state.
  * Aggregate Deep Research selector counts across iframes.

* **Tests**
  * Expanded coverage across jobs, runner, error classification, response handling, and Google Drive checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->