### PR TITLE
fix(process-lock): serialise stale-lock takeover via a recoverable replacement gate

### DIFF
--- a/src/core/process-lock.ts
+++ b/src/core/process-lock.ts
@@ -3,21 +3,23 @@
  * running simultaneously and interfering with the shared CDP context.
  *
  * Uses an exclusive-create lock file (`~/.cavendish/cavendish.lock`)
- * with the owning PID written inside.
+ * with the owning PID written inside.  Stale-lock takeover is
+ * serialised through a sibling "replacement gate" file so concurrent
+ * claimers cannot accidentally destroy a freshly acquired lock.
+ * The gate itself is recoverable: if its holder dies mid-takeover,
+ * the next claimer detects the dead holder and reclaims the gate.
  */
 
-import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { CAVENDISH_DIR } from './browser-manager.js';
 import { CavendishError } from './errors.js';
+import { isErrnoException } from './jobs/pid-utils.js';
 
 const LOCK_FILE = join(CAVENDISH_DIR, 'cavendish.lock');
-
-/** Type guard for Node.js system errors that carry an `errno` code. */
-function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
-  return err instanceof Error && 'code' in err;
-}
+const LOCK_REPLACEMENT_GATE = `${LOCK_FILE}.gate`;
+const GATE_RECLAIM_ATTEMPTS = 2;
 
 /**
  * Check whether a process with the given PID is still running.
@@ -36,13 +38,10 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-/**
- * Read the PID from an existing lock file.
- * Returns null if the file cannot be read or parsed.
- */
-function readLockPid(): number | null {
+/** Read a PID from the file at `path`.  Null when missing/unparseable. */
+function readPidFile(path: string): number | null {
   try {
-    const content = readFileSync(LOCK_FILE, 'utf8').trim();
+    const content = readFileSync(path, 'utf8').trim();
     const pid = parseInt(content, 10);
     if (isNaN(pid) || pid <= 0) {
       return null;
@@ -53,15 +52,31 @@ function readLockPid(): number | null {
   }
 }
 
+/** Read the PID of the canonical lock file's owner. */
+function readLockPid(): number | null {
+  return readPidFile(LOCK_FILE);
+}
+
+/** Unlink `path`, ignoring ENOENT.  Other errors propagate. */
+function unlinkIfPresent(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch (err: unknown) {
+    if (!isErrnoException(err) || err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+}
+
 /**
- * Attempt to create the lock file atomically.
+ * Attempt to create the lock file atomically with the given pid.
  * Returns true on success, false if the file already exists.
  *
  * @throws {Error} on unexpected filesystem errors (not EEXIST).
  */
-function tryCreateLockFile(): boolean {
+function tryCreateLockFile(currentPid: number): boolean {
   try {
-    writeFileSync(LOCK_FILE, String(process.pid), { flag: 'wx', mode: 0o600 });
+    writeFileSync(LOCK_FILE, String(currentPid), { flag: 'wx', mode: 0o600 });
     return true;
   } catch (err: unknown) {
     if (isErrnoException(err) && err.code === 'EEXIST') {
@@ -72,39 +87,87 @@ function tryCreateLockFile(): boolean {
 }
 
 /**
- * Atomically claim a stale lock by writing our PID to a temporary file
- * and renaming it over the lock file.
+ * Try to acquire the replacement gate exclusively.
  *
- * `rename()` is atomic on POSIX — it replaces the lock file in a single
- * syscall, eliminating the TOCTOU gap between a separate `unlink()` and
- * `writeFileSync(..., 'wx')`.  If another process races us, exactly one
- * rename will take effect last.  We then verify we won by re-reading
- * the lock file.
+ * The gate is a `wx`-created file containing the holder's pid.  Two
+ * concurrent claimers cannot both create it; the loser inspects the
+ * recorded pid and either bails out (if the holder is alive) or
+ * reclaims the gate (if the holder is dead).
  *
- * Returns true if this process successfully claimed the lock.
+ * Returns true when this caller now owns the gate; false otherwise.
  */
-function tryClaimStaleLock(): boolean {
-  const tmpFile = `${LOCK_FILE}.${String(process.pid)}`;
-  try {
-    writeFileSync(tmpFile, String(process.pid), { mode: 0o600 });
-    renameSync(tmpFile, LOCK_FILE);
-    // Verify that our PID is actually in the lock file.
-    // Another process may have renamed over it after us.
-    const winner = readLockPid();
-    return winner === process.pid;
-  } catch (err: unknown) {
-    // Clean up the temp file on any error
+function tryAcquireReplacementGate(currentPid: number): boolean {
+  for (let attempt = 0; attempt < GATE_RECLAIM_ATTEMPTS; attempt++) {
     try {
-      unlinkSync(tmpFile);
-    } catch {
-      // Temp file may not exist — safe to ignore
+      writeFileSync(LOCK_REPLACEMENT_GATE, String(currentPid), { flag: 'wx', mode: 0o600 });
+      return true;
+    } catch (err: unknown) {
+      if (!isErrnoException(err) || err.code !== 'EEXIST') {
+        throw err;
+      }
     }
-    // Propagate filesystem errors (EACCES, EROFS, ENOSPC) so the caller
-    // can report the real cause instead of misclassifying as a race loss.
-    if (isErrnoException(err) && err.code !== 'ENOENT') {
-      throw err;
+
+    const holderPid = readPidFile(LOCK_REPLACEMENT_GATE);
+    if (holderPid !== null && isProcessAlive(holderPid)) {
+      return false;
     }
+    // Holder is dead or the gate file is corrupt — reclaim and retry.
+    unlinkIfPresent(LOCK_REPLACEMENT_GATE);
+  }
+  return false;
+}
+
+/**
+ * Release the replacement gate.
+ *
+ * Only called from the `finally` of {@link tryClaimStaleLock} after
+ * `tryAcquireReplacementGate` returned true, so within this synchronous
+ * frame we are guaranteed to be the gate's holder.
+ */
+function releaseReplacementGate(): void {
+  try {
+    unlinkIfPresent(LOCK_REPLACEMENT_GATE);
+  } catch (err: unknown) {
+    process.stderr.write(
+      `[cavendish] Warning: failed to release replacement gate "${LOCK_REPLACEMENT_GATE}": ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+/**
+ * Atomically take over a stale lock.
+ *
+ * Stale-lock takeover requires three logical steps that are not
+ * individually atomic on POSIX (verify content → remove → recreate).
+ * Two concurrent claimers that both observe the same stale pid can
+ * race so that the slower one ends up destroying the faster one's
+ * freshly created lock.
+ *
+ * To prevent that, we serialise the takeover through an exclusive
+ * replacement gate.  Inside the gate we re-verify the stale pid,
+ * unlink the stale lock, and `wx`-create the new one — none of
+ * which can race against another stale-takeover, because the gate
+ * holder has exclusive access until it releases the gate.
+ *
+ * Concurrent fresh acquirers (`tryCreateLockFile` only, no takeover)
+ * still race normally against the `wx`-create inside the gate; the
+ * `wx` flag's atomic EEXIST guarantees at most one writer wins.
+ *
+ * Returns true only when this caller actually installed a lock holding
+ * its own pid.
+ */
+function tryClaimStaleLock(stalePid: number | null, currentPid: number): boolean {
+  if (!tryAcquireReplacementGate(currentPid)) {
     return false;
+  }
+  try {
+    if (readLockPid() !== stalePid) {
+      return false;
+    }
+    unlinkIfPresent(LOCK_FILE);
+    return tryCreateLockFile(currentPid);
+  } finally {
+    releaseReplacementGate();
   }
 }
 
@@ -113,7 +176,8 @@ function tryClaimStaleLock(): boolean {
  *
  * - Attempts exclusive creation of the lock file.
  * - If the file exists, checks whether the owning process is alive.
- * - Stale locks (dead process) are removed and retried once.
+ * - Stale locks (dead process or unparseable content) are taken over
+ *   atomically through a replacement gate.
  * - If the owning process is alive, throws with an actionable error.
  *
  * @throws {CavendishError} when another cavendish process is running.
@@ -124,11 +188,11 @@ export function acquireLock(): void {
   // which normally creates the directory via ensureProfileDirectories().
   mkdirSync(CAVENDISH_DIR, { recursive: true });
 
-  if (tryCreateLockFile()) {
+  if (tryCreateLockFile(process.pid)) {
     return;
   }
 
-  // Lock file exists — check if the owning process is still alive
+  // Lock file exists — check if the owning process is still alive.
   const existingPid = readLockPid();
 
   // Re-entrancy guard: if this process already holds the lock, return early.
@@ -146,12 +210,12 @@ export function acquireLock(): void {
     );
   }
 
-  // Stale lock from a dead process — atomically claim it via rename.
-  if (tryClaimStaleLock()) {
+  if (tryClaimStaleLock(existingPid, process.pid)) {
     return;
   }
 
-  // Another process won the rename race
+  // Either another process took over the stale lock first, or holds the
+  // replacement gate.  Surface whichever owner the next reader sees.
   const racePid = readLockPid();
   const pidInfo = racePid !== null ? ` (PID: ${String(racePid)})` : '';
   throw new CavendishError(
@@ -169,16 +233,12 @@ export function acquireLock(): void {
  * Silently succeeds if the lock file does not exist.
  */
 export function releaseLock(): void {
-  const pid = readLockPid();
-  if (pid !== process.pid) {
+  if (readLockPid() !== process.pid) {
     return;
   }
   try {
     unlinkSync(LOCK_FILE);
   } catch (err: unknown) {
-    // ENOENT is expected (file already removed) — anything else
-    // (EACCES, EPERM, EROFS) indicates a real problem that could
-    // leave a stale lock and block future invocations.
     if (isErrnoException(err) && err.code !== 'ENOENT') {
       process.stderr.write(
         `[cavendish] Warning: failed to release lock file: ${err.message}\n`,
@@ -187,7 +247,18 @@ export function releaseLock(): void {
   }
 }
 
-/**
- * The lock file path, exported for test verification.
- */
+/** The lock file path, exported for test verification. */
 export const LOCK_FILE_PATH = LOCK_FILE;
+
+/** The replacement gate path, exported for test verification. */
+export const LOCK_REPLACEMENT_GATE_PATH = LOCK_REPLACEMENT_GATE;
+
+/**
+ * Test-only export of the internal `tryClaimStaleLock` helper.
+ *
+ * Production code MUST NOT call this directly — `acquireLock` is the
+ * only supported entry point.  This export takes an explicit
+ * `currentPid` so {@link tests/process-lock-race.test.ts} can simulate
+ * two concurrent claimers in a single process without forking.
+ */
+export const _tryClaimStaleLockForTests = tryClaimStaleLock;

--- a/tests/process-lock-race.test.ts
+++ b/tests/process-lock-race.test.ts
@@ -15,12 +15,10 @@ const STALE_PID = 999_999_999;
 const DEAD_GATE_PID = 999_999_998;
 
 let testRoot: string;
-let fakeLockFile: string;
 
 beforeEach(() => {
   testRoot = join(tmpdir(), `cavendish-lock-race-test-${randomUUID()}`);
   mkdirSync(join(testRoot, '.cavendish'), { recursive: true });
-  fakeLockFile = join(testRoot, '.cavendish', 'cavendish.lock');
 });
 
 afterEach(() => {
@@ -51,64 +49,64 @@ async function importWithMockedHome(): Promise<{
   };
 }
 
-function writeStaleLock(pid: number = STALE_PID): void {
-  writeFileSync(fakeLockFile, String(pid), { flag: 'wx' });
+function writeStaleLock(lockFilePath: string, pid: number = STALE_PID): void {
+  writeFileSync(lockFilePath, String(pid), { flag: 'wx' });
 }
 
 describe('tryClaimStaleLock — race resistance', () => {
   it('a second claim with the same stale-pid expectation fails after the first succeeds', async () => {
-    const { tryClaim } = await importWithMockedHome();
-    writeStaleLock();
+    const { tryClaim, LOCK_FILE_PATH } = await importWithMockedHome();
+    writeStaleLock(LOCK_FILE_PATH);
 
     expect(tryClaim(STALE_PID, 100)).toBe(true);
-    expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe('100');
+    expect(readFileSync(LOCK_FILE_PATH, 'utf8').trim()).toBe('100');
 
     // Process B captured the same stale pid before A claimed and now
     // races to claim.  The lock now actually holds A's pid, so B must
     // refuse to overwrite it.
     expect(tryClaim(STALE_PID, 200)).toBe(false);
-    expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe('100');
+    expect(readFileSync(LOCK_FILE_PATH, 'utf8').trim()).toBe('100');
   });
 
   it('returns false when the lock has already been recreated by a third party', async () => {
-    const { tryClaim } = await importWithMockedHome();
-    writeFileSync(fakeLockFile, '12345', { flag: 'wx' });
+    const { tryClaim, LOCK_FILE_PATH } = await importWithMockedHome();
+    writeFileSync(LOCK_FILE_PATH, '12345', { flag: 'wx' });
 
     expect(tryClaim(STALE_PID, 100)).toBe(false);
-    expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe('12345');
+    expect(readFileSync(LOCK_FILE_PATH, 'utf8').trim()).toBe('12345');
   });
 
   it('returns false when the lock file has been removed entirely', async () => {
-    const { tryClaim } = await importWithMockedHome();
-    expect(existsSync(fakeLockFile)).toBe(false);
+    const { tryClaim, LOCK_FILE_PATH } = await importWithMockedHome();
+    expect(existsSync(LOCK_FILE_PATH)).toBe(false);
     expect(tryClaim(STALE_PID, 100)).toBe(false);
   });
 
   it('releases the replacement gate on success so the next claim can proceed', async () => {
-    const { tryClaim, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
-    writeStaleLock();
+    const { tryClaim, LOCK_FILE_PATH, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
+    writeStaleLock(LOCK_FILE_PATH);
 
     expect(tryClaim(STALE_PID, 100)).toBe(true);
     expect(existsSync(LOCK_REPLACEMENT_GATE_PATH)).toBe(false);
   });
 
   it('releases the replacement gate even when a stale-pid mismatch causes early exit', async () => {
-    const { tryClaim, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
-    writeFileSync(fakeLockFile, '12345', { flag: 'wx' });
+    const { tryClaim, LOCK_FILE_PATH, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
+    writeFileSync(LOCK_FILE_PATH, '12345', { flag: 'wx' });
 
     expect(tryClaim(STALE_PID, 100)).toBe(false);
     expect(existsSync(LOCK_REPLACEMENT_GATE_PATH)).toBe(false);
-    expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe('12345');
+    expect(readFileSync(LOCK_FILE_PATH, 'utf8').trim()).toBe('12345');
   });
 
   it('a second claim sees the gate held by a live process and bails out without overwriting', async () => {
-    const { tryClaim, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
-    writeStaleLock();
+    const { tryClaim, LOCK_FILE_PATH, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
+    writeStaleLock(LOCK_FILE_PATH);
     // The gate's holder pid is the test runner itself — guaranteed alive.
     writeFileSync(LOCK_REPLACEMENT_GATE_PATH, String(process.pid), { flag: 'wx' });
     try {
       expect(tryClaim(STALE_PID, 200)).toBe(false);
-      expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe(String(STALE_PID));
+      expect(readFileSync(LOCK_FILE_PATH, 'utf8').trim()).toBe(String(STALE_PID));
       expect(readFileSync(LOCK_REPLACEMENT_GATE_PATH, 'utf8').trim()).toBe(String(process.pid));
     } finally {
       rmSync(LOCK_REPLACEMENT_GATE_PATH, { force: true });
@@ -116,22 +114,22 @@ describe('tryClaimStaleLock — race resistance', () => {
   });
 
   it('reclaims a replacement gate abandoned by a dead holder', async () => {
-    const { tryClaim, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
-    writeStaleLock();
+    const { tryClaim, LOCK_FILE_PATH, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
+    writeStaleLock(LOCK_FILE_PATH);
     writeFileSync(LOCK_REPLACEMENT_GATE_PATH, String(DEAD_GATE_PID), { flag: 'wx' });
 
     expect(tryClaim(STALE_PID, 100)).toBe(true);
-    expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe('100');
+    expect(readFileSync(LOCK_FILE_PATH, 'utf8').trim()).toBe('100');
     expect(existsSync(LOCK_REPLACEMENT_GATE_PATH)).toBe(false);
   });
 
   it('reclaims a replacement gate whose holder pid file is corrupt', async () => {
-    const { tryClaim, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
-    writeStaleLock();
+    const { tryClaim, LOCK_FILE_PATH, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
+    writeStaleLock(LOCK_FILE_PATH);
     writeFileSync(LOCK_REPLACEMENT_GATE_PATH, 'not-a-pid', { flag: 'wx' });
 
     expect(tryClaim(STALE_PID, 100)).toBe(true);
-    expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe('100');
+    expect(readFileSync(LOCK_FILE_PATH, 'utf8').trim()).toBe('100');
     expect(existsSync(LOCK_REPLACEMENT_GATE_PATH)).toBe(false);
   });
 });

--- a/tests/process-lock-race.test.ts
+++ b/tests/process-lock-race.test.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Race-resistance regression tests for `tryClaimStaleLock`.  Uses the
+ * `_tryClaimStaleLockForTests` export to drive two simulated claimers
+ * with distinct pids in a single process.
+ */
+
+const STALE_PID = 999_999_999;
+const DEAD_GATE_PID = 999_999_998;
+
+let testRoot: string;
+let fakeLockFile: string;
+
+beforeEach(() => {
+  testRoot = join(tmpdir(), `cavendish-lock-race-test-${randomUUID()}`);
+  mkdirSync(join(testRoot, '.cavendish'), { recursive: true });
+  fakeLockFile = join(testRoot, '.cavendish', 'cavendish.lock');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+async function importWithMockedHome(): Promise<{
+  tryClaim: (stalePid: number | null, currentPid: number) => boolean;
+  LOCK_FILE_PATH: string;
+  LOCK_REPLACEMENT_GATE_PATH: string;
+}> {
+  vi.resetModules();
+  vi.doMock('node:os', async () => {
+    const realOs = await vi.importActual<typeof import('node:os')>('node:os');
+    return {
+      ...realOs,
+      homedir: (): string => testRoot,
+    };
+  });
+
+  const mod = await import('../src/core/process-lock.js');
+  return {
+    tryClaim: mod._tryClaimStaleLockForTests,
+    LOCK_FILE_PATH: mod.LOCK_FILE_PATH,
+    LOCK_REPLACEMENT_GATE_PATH: mod.LOCK_REPLACEMENT_GATE_PATH,
+  };
+}
+
+function writeStaleLock(pid: number = STALE_PID): void {
+  writeFileSync(fakeLockFile, String(pid), { flag: 'wx' });
+}
+
+describe('tryClaimStaleLock — race resistance', () => {
+  it('a second claim with the same stale-pid expectation fails after the first succeeds', async () => {
+    const { tryClaim } = await importWithMockedHome();
+    writeStaleLock();
+
+    expect(tryClaim(STALE_PID, 100)).toBe(true);
+    expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe('100');
+
+    // Process B captured the same stale pid before A claimed and now
+    // races to claim.  The lock now actually holds A's pid, so B must
+    // refuse to overwrite it.
+    expect(tryClaim(STALE_PID, 200)).toBe(false);
+    expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe('100');
+  });
+
+  it('returns false when the lock has already been recreated by a third party', async () => {
+    const { tryClaim } = await importWithMockedHome();
+    writeFileSync(fakeLockFile, '12345', { flag: 'wx' });
+
+    expect(tryClaim(STALE_PID, 100)).toBe(false);
+    expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe('12345');
+  });
+
+  it('returns false when the lock file has been removed entirely', async () => {
+    const { tryClaim } = await importWithMockedHome();
+    expect(existsSync(fakeLockFile)).toBe(false);
+    expect(tryClaim(STALE_PID, 100)).toBe(false);
+  });
+
+  it('releases the replacement gate on success so the next claim can proceed', async () => {
+    const { tryClaim, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
+    writeStaleLock();
+
+    expect(tryClaim(STALE_PID, 100)).toBe(true);
+    expect(existsSync(LOCK_REPLACEMENT_GATE_PATH)).toBe(false);
+  });
+
+  it('releases the replacement gate even when a stale-pid mismatch causes early exit', async () => {
+    const { tryClaim, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
+    writeFileSync(fakeLockFile, '12345', { flag: 'wx' });
+
+    expect(tryClaim(STALE_PID, 100)).toBe(false);
+    expect(existsSync(LOCK_REPLACEMENT_GATE_PATH)).toBe(false);
+    expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe('12345');
+  });
+
+  it('a second claim sees the gate held by a live process and bails out without overwriting', async () => {
+    const { tryClaim, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
+    writeStaleLock();
+    // The gate's holder pid is the test runner itself — guaranteed alive.
+    writeFileSync(LOCK_REPLACEMENT_GATE_PATH, String(process.pid), { flag: 'wx' });
+    try {
+      expect(tryClaim(STALE_PID, 200)).toBe(false);
+      expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe(String(STALE_PID));
+      expect(readFileSync(LOCK_REPLACEMENT_GATE_PATH, 'utf8').trim()).toBe(String(process.pid));
+    } finally {
+      rmSync(LOCK_REPLACEMENT_GATE_PATH, { force: true });
+    }
+  });
+
+  it('reclaims a replacement gate abandoned by a dead holder', async () => {
+    const { tryClaim, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
+    writeStaleLock();
+    writeFileSync(LOCK_REPLACEMENT_GATE_PATH, String(DEAD_GATE_PID), { flag: 'wx' });
+
+    expect(tryClaim(STALE_PID, 100)).toBe(true);
+    expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe('100');
+    expect(existsSync(LOCK_REPLACEMENT_GATE_PATH)).toBe(false);
+  });
+
+  it('reclaims a replacement gate whose holder pid file is corrupt', async () => {
+    const { tryClaim, LOCK_REPLACEMENT_GATE_PATH } = await importWithMockedHome();
+    writeStaleLock();
+    writeFileSync(LOCK_REPLACEMENT_GATE_PATH, 'not-a-pid', { flag: 'wx' });
+
+    expect(tryClaim(STALE_PID, 100)).toBe(true);
+    expect(readFileSync(fakeLockFile, 'utf8').trim()).toBe('100');
+    expect(existsSync(LOCK_REPLACEMENT_GATE_PATH)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- 二つの cavendish プロセスが同じ stale pid を観測した場合、それぞれが自分の tmp を `renameSync` で lock 上書きしてから自身の pid を verify することで両方 success を返してしまうレースを修正。実際は最後の書き手のみが lock を保持しているのに両者が「自分が lock を取得した」と認識する状態だった。
- 排他的な replacement gate (sibling `cavendish.lock.gate`) を導入し、stale-takeover の `unlink` → `wx`-create を gate 保持者に直列化。
- gate 自体は回復可能。保持者が `finally` を走らせる前に死んだ場合、次の claimer が dead holder pid を検出して reclaim する。

## Behaviour change

- 既存の単体取得・再入・stale 復帰の挙動はそのまま。
- 同時 stale-takeover を試みた場合、勝者の lock が後発の claimer の `renameSync` で上書きされたり破壊されたりしない。

## Test plan

- [x] `npm run lint && npm run typecheck && npm test` (454 passed)
- [x] 新規 `tests/process-lock-race.test.ts` で 2 つの claimer を 1 プロセス内でシミュレート
  - 同じ stale pid 期待で 2 回目が成功しないこと
  - gate が live holder にロックされている場合に no-op で false を返すこと
  - dead holder / corrupt gate ファイルが reclaim されること
- [x] 既存 `tests/process-lock.test.ts` 全パス
- [x] `cavendish doctor` / `ask --sync` ローカルで稼働確認 (PR #230 マージ後の main で動作)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/cavendish/pull/231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reworked stale-lock takeover to be more robust and race-resistant, improving reliability when multiple processes contend for locks.

* **Tests**
  * Added a comprehensive regression suite validating stale-lock claiming, gate recovery, and edge cases (concurrent holders, missing or corrupt state, and cleanup behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->