### PR TITLE
fix(delete): verify conversation actually disappears after delete

### DIFF
--- a/src/core/chatgpt-driver.ts
+++ b/src/core/chatgpt-driver.ts
@@ -28,6 +28,11 @@ import { progress } from './output-handler.js';
 export type { ConversationItem, ConversationMessage, DeepResearchExportFormat, ProjectItem, WaitForResponseOptions, WaitForResponseResult } from './chatgpt-types.js';
 export type { ThinkingEffortLevel } from './model-config.js';
 
+/** Total budget for confirming a deleted conversation has stayed removed. */
+const DELETE_VERIFY_TIMEOUT_MS = 5_000;
+/** Consecutive zero-count polls required to consider the absence stable. */
+const DELETE_VERIFY_STABILITY_TARGET = 3;
+
 export class ChatGPTDriver {
   private readonly page: Page;
 
@@ -197,7 +202,7 @@ export class ChatGPTDriver {
   async deleteConversation(id: string, quiet = false): Promise<void> {
     progress(`Deleting conversation: ${id}`, quiet);
     const link = await this.openConversationMenu(id, quiet);
-    await this.confirmDeleteAndWait(link);
+    await this.confirmDeleteAndWait(link, id);
     progress('Conversation deleted', quiet);
   }
 
@@ -275,7 +280,7 @@ export class ChatGPTDriver {
   async deleteProjectConversation(id: string, quiet = false): Promise<void> {
     progress(`Deleting project conversation: ${id}`, quiet);
     const link = await this.openProjectConversationMenu(id);
-    await this.confirmDeleteAndWait(link);
+    await this.confirmDeleteAndWait(link, id);
     progress('Project conversation deleted', quiet);
   }
 
@@ -580,10 +585,50 @@ export class ChatGPTDriver {
 
   // ── Private ────────────────────────────────────────────────
 
-  private async confirmDeleteAndWait(link: Locator): Promise<void> {
-    await this.page.locator(SELECTORS.CONVERSATION_DELETE_OPTION).click();
-    await this.page.locator(SELECTORS.CONVERSATION_DELETE_CONFIRM).click();
-    await link.waitFor({ state: 'detached', timeout: 10_000 });
+  private async confirmDeleteAndWait(link: Locator, id: string): Promise<void> {
+    const deleteOption = this.page.locator(SELECTORS.CONVERSATION_DELETE_OPTION);
+    await deleteOption.waitFor({ state: 'visible', timeout: 5_000 });
+    await deleteOption.click();
+
+    // Confirming the delete is split from observing the result so a
+    // transient sidebar re-render between the two clicks cannot be
+    // mistaken for the conversation having actually been removed.
+    const confirmButton = this.page.locator(SELECTORS.CONVERSATION_DELETE_CONFIRM);
+    await confirmButton.waitFor({ state: 'visible', timeout: 5_000 });
+    await confirmButton.click();
+    await confirmButton.waitFor({ state: 'detached', timeout: 10_000 });
+
+    await this.expectConversationLinkGone(link, id);
+  }
+
+  /**
+   * Verify the conversation link is consistently absent from the DOM.
+   *
+   * The sidebar can transiently detach a link during re-render even
+   * when the conversation persists, so a single `state: 'detached'`
+   * observation is not enough.  Require the absence to be stable
+   * across several consecutive polls before declaring success.
+   */
+  private async expectConversationLinkGone(link: Locator, id: string): Promise<void> {
+    const deadline = Date.now() + DELETE_VERIFY_TIMEOUT_MS;
+    let stableObservations = 0;
+
+    while (Date.now() < deadline) {
+      const count = await link.count();
+      if (count === 0) {
+        stableObservations++;
+        if (stableObservations >= DELETE_VERIFY_STABILITY_TARGET) {
+          return;
+        }
+      } else {
+        stableObservations = 0;
+      }
+      await delay(POLL_INTERVAL_MS);
+    }
+
+    throw new Error(
+      `Delete verification failed: conversation "${id}" reappeared in the sidebar after ${String(DELETE_VERIFY_TIMEOUT_MS / 1000)}s.`,
+    );
   }
 
   private async waitForSidebarContainer(quiet: boolean): Promise<void> {

--- a/src/core/chatgpt-driver.ts
+++ b/src/core/chatgpt-driver.ts
@@ -29,9 +29,59 @@ export type { ConversationItem, ConversationMessage, DeepResearchExportFormat, P
 export type { ThinkingEffortLevel } from './model-config.js';
 
 /** Total budget for confirming a deleted conversation has stayed removed. */
-const DELETE_VERIFY_TIMEOUT_MS = 5_000;
+export const DELETE_VERIFY_TIMEOUT_MS = 5_000;
 /** Consecutive zero-count polls required to consider the absence stable. */
-const DELETE_VERIFY_STABILITY_TARGET = 3;
+export const DELETE_VERIFY_STABILITY_TARGET = 3;
+
+/**
+ * Verify a conversation link is consistently absent from the DOM.
+ *
+ * The sidebar (and the project main area) can transiently detach a link
+ * during re-render even when the conversation persists, so a single
+ * `state: 'detached'` observation is not enough.  Poll until the absence
+ * is stable across `stabilityTarget` consecutive observations or throw on
+ * timeout.
+ *
+ * Exported as a free function so it can be unit-tested with a mocked
+ * `count` callback and a mocked `sleep`.
+ */
+export async function expectConversationLinkGone(
+  count: () => Promise<number>,
+  id: string,
+  options: {
+    timeoutMs?: number;
+    stabilityTarget?: number;
+    pollIntervalMs?: number;
+    sleep?: (ms: number) => Promise<void>;
+    now?: () => number;
+  } = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? DELETE_VERIFY_TIMEOUT_MS;
+  const stabilityTarget = options.stabilityTarget ?? DELETE_VERIFY_STABILITY_TARGET;
+  const pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
+  const sleep = options.sleep ?? delay;
+  const now = options.now ?? Date.now;
+
+  const deadline = now() + timeoutMs;
+  let stableObservations = 0;
+
+  while (now() < deadline) {
+    const observed = await count();
+    if (observed === 0) {
+      stableObservations++;
+      if (stableObservations >= stabilityTarget) {
+        return;
+      }
+    } else {
+      stableObservations = 0;
+    }
+    await sleep(pollIntervalMs);
+  }
+
+  throw new Error(
+    `Delete verification failed: conversation "${id}" was not reliably removed within ${String(timeoutMs / 1000)}s.`,
+  );
+}
 
 export class ChatGPTDriver {
   private readonly page: Page;
@@ -598,37 +648,7 @@ export class ChatGPTDriver {
     await confirmButton.click();
     await confirmButton.waitFor({ state: 'detached', timeout: 10_000 });
 
-    await this.expectConversationLinkGone(link, id);
-  }
-
-  /**
-   * Verify the conversation link is consistently absent from the DOM.
-   *
-   * The sidebar can transiently detach a link during re-render even
-   * when the conversation persists, so a single `state: 'detached'`
-   * observation is not enough.  Require the absence to be stable
-   * across several consecutive polls before declaring success.
-   */
-  private async expectConversationLinkGone(link: Locator, id: string): Promise<void> {
-    const deadline = Date.now() + DELETE_VERIFY_TIMEOUT_MS;
-    let stableObservations = 0;
-
-    while (Date.now() < deadline) {
-      const count = await link.count();
-      if (count === 0) {
-        stableObservations++;
-        if (stableObservations >= DELETE_VERIFY_STABILITY_TARGET) {
-          return;
-        }
-      } else {
-        stableObservations = 0;
-      }
-      await delay(POLL_INTERVAL_MS);
-    }
-
-    throw new Error(
-      `Delete verification failed: conversation "${id}" reappeared in the sidebar after ${String(DELETE_VERIFY_TIMEOUT_MS / 1000)}s.`,
-    );
+    await expectConversationLinkGone(() => link.count(), id);
   }
 
   private async waitForSidebarContainer(quiet: boolean): Promise<void> {

--- a/tests/expect-conversation-link-gone.test.ts
+++ b/tests/expect-conversation-link-gone.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DELETE_VERIFY_STABILITY_TARGET,
+  DELETE_VERIFY_TIMEOUT_MS,
+  expectConversationLinkGone,
+} from '../src/core/chatgpt-driver.js';
+
+describe('expectConversationLinkGone', () => {
+  function fakeClock(): { now: () => number; advance: (ms: number) => void } {
+    let current = 0;
+    return {
+      now: (): number => current,
+      advance: (ms: number): void => {
+        current += ms;
+      },
+    };
+  }
+
+  function makeSleep(clock: { advance: (ms: number) => void }): (ms: number) => Promise<void> {
+    return (ms: number): Promise<void> => {
+      clock.advance(ms);
+      return Promise.resolve();
+    };
+  }
+
+  it('resolves once count() returns zero for STABILITY_TARGET consecutive polls', async () => {
+    const clock = fakeClock();
+    const counts = [0, 0, 0];
+    const count = vi.fn((): Promise<number> => Promise.resolve(counts.shift() ?? 0));
+
+    await expectConversationLinkGone(count, 'abc', {
+      sleep: makeSleep(clock),
+      now: clock.now,
+    });
+
+    expect(count).toHaveBeenCalledTimes(DELETE_VERIFY_STABILITY_TARGET);
+  });
+
+  it('resets the stability counter when the link reappears', async () => {
+    // 0, 0, >0 (reset), 0, 0, 0 → resolves
+    const clock = fakeClock();
+    const counts = [0, 0, 1, 0, 0, 0];
+    const count = vi.fn((): Promise<number> => Promise.resolve(counts.shift() ?? 0));
+
+    await expectConversationLinkGone(count, 'abc', {
+      sleep: makeSleep(clock),
+      now: clock.now,
+    });
+
+    expect(count).toHaveBeenCalledTimes(6);
+  });
+
+  it('throws when the link never disappears within the timeout', async () => {
+    const clock = fakeClock();
+    const count = vi.fn((): Promise<number> => Promise.resolve(1));
+
+    await expect(
+      expectConversationLinkGone(count, 'abc', {
+        sleep: makeSleep(clock),
+        now: clock.now,
+        timeoutMs: 1_000,
+        pollIntervalMs: 100,
+      }),
+    ).rejects.toThrow(/Delete verification failed.*"abc".*not reliably removed/);
+  });
+
+  it('uses a generic error message that does not assume sidebar location', async () => {
+    // Project conversations live in <main>, not the sidebar.  The error
+    // message must not say "reappeared in the sidebar".
+    const clock = fakeClock();
+    const count = vi.fn((): Promise<number> => Promise.resolve(1));
+
+    try {
+      await expectConversationLinkGone(count, 'project-chat', {
+        sleep: makeSleep(clock),
+        now: clock.now,
+        timeoutMs: 500,
+        pollIntervalMs: 100,
+      });
+      expect.fail('expected the call to throw');
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      expect(message).not.toContain('sidebar');
+      expect(message).toContain('project-chat');
+    }
+  });
+
+  it('does NOT resolve after fewer than STABILITY_TARGET zero observations', async () => {
+    // Only 2 consecutive zeros (below the target of 3) followed by a
+    // reappearance must reset the counter and continue polling — never
+    // resolve early.
+    const clock = fakeClock();
+    const counts = [0, 0, 1, 1, 1, 1, 1];
+    const count = vi.fn((): Promise<number> => Promise.resolve(counts.shift() ?? 1));
+
+    await expect(
+      expectConversationLinkGone(count, 'abc', {
+        sleep: makeSleep(clock),
+        now: clock.now,
+        timeoutMs: 1_000,
+        pollIntervalMs: 100,
+      }),
+    ).rejects.toThrow();
+    expect(count.mock.calls.length).toBeGreaterThan(2);
+  });
+
+  it('exposes the configured timeout in the error message', async () => {
+    const clock = fakeClock();
+    const count = vi.fn((): Promise<number> => Promise.resolve(1));
+
+    try {
+      await expectConversationLinkGone(count, 'abc', {
+        sleep: makeSleep(clock),
+        now: clock.now,
+        timeoutMs: 5_000,
+        pollIntervalMs: 100,
+      });
+      expect.fail('expected the call to throw');
+    } catch (e: unknown) {
+      expect((e as Error).message).toContain('5s');
+    }
+  });
+
+  it('verifies module exports the documented constants', () => {
+    expect(DELETE_VERIFY_TIMEOUT_MS).toBe(5_000);
+    expect(DELETE_VERIFY_STABILITY_TARGET).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- `confirmDeleteAndWait` は `link.waitFor({state:'detached'})` を成功条件にしていたため、ダイアログ閉じ時の sidebar 再レンダリングで一時的に locator が 0 件にマッチした瞬間を「削除成功」と誤判定していた。バッチ delete 時に最後の 1 件で観測。
- 実機確認: 修正前は 7 件中 1 件が「削除済み」と表示されたのに `read` で取得可能だった。修正後は (1) 削除メニュー項目の visible 待ち → click、(2) 確認ボタン visible 待ち → click → 確認ボタンが detached になるまで待機、(3) link locator の `count()` を `POLL_INTERVAL_MS` 間隔で監視し 3 回連続 0 を確認、で安定的に消失を判定する。
- 失敗時は `Delete verification failed: conversation "${id}" reappeared in the sidebar after Ns.` を投げる (silent success にしない)。

## Behaviour change

- 削除成功までの所要時間がチャットあたり 〜600ms 程度増える (3 × 200ms の安定待機)。バッチ削除時は累積するが許容範囲。
- 削除が実際に反映されなかった場合に明示エラーになる。

## Test plan

- [x] `npm run lint && npm run typecheck && npm test` (446 passed)
- [x] **Live Chrome test**: 3 件の test chat を `cavendish ask --sync` で作成し `cavendish delete <id1> <id2> <id3>` を実行 → `cavendish read` がいずれも `selector_miss` を返す (会話なし) ことを確認。修正前は最後の 1 件が読み取れる挙動だった。
- [x] 単体 delete も同様にライブ確認。test chat はすべて削除済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/cavendish/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of conversation deletion by implementing polling-based verification to ensure deletions complete successfully before confirming the action.

* **Tests**
  * Added comprehensive test coverage for deletion verification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->