### PR TITLE
fix(deep-research): make follow-up completion detection robust

### DIFF
--- a/src/commands/deep-research.ts
+++ b/src/commands/deep-research.ts
@@ -323,11 +323,18 @@ async function handleDryRunOrDetach(
 }
 
 /**
- * Send the DR query/action and return a pre-action text snapshot.
- * For follow-up/refresh, the snapshot is taken after navigation but before
- * the action (send/click) so stale-content detection works correctly.
+ * Send the DR query/action and return a pre-action snapshot of iframe state.
+ * For follow-up/refresh, the snapshot (text + export-button visibility) is
+ * taken after navigation but before the action so stale-content / stale-
+ * export detection works correctly. For initial mode there is no prior
+ * state so the snapshot is empty / `false`.
  */
-async function sendQuery(driver: ChatGPTDriver, mode: RunMode, quiet: boolean, timeoutMs: number): Promise<string> {
+async function sendQuery(
+  driver: ChatGPTDriver,
+  mode: RunMode,
+  quiet: boolean,
+  timeoutMs: number,
+): Promise<{ text: string; hasExport: boolean }> {
   const deadline = Date.now() + timeoutMs;
   switch (mode.kind) {
     case 'refresh': {
@@ -345,7 +352,7 @@ async function sendQuery(driver: ChatGPTDriver, mode: RunMode, quiet: boolean, t
       }
       progress('Sending Deep Research query...', quiet);
       await driver.sendDeepResearchMessage(mode.prompt);
-      return '';
+      return { text: '', hasExport: false };
   }
 }
 
@@ -466,7 +473,7 @@ export const deepResearchCommand = defineCommand({
     await withDriver(quiet, async (driver) => {
       if (stream) { emitState('sending'); }
       verbose('Sending Deep Research query...', isVerbose);
-      const preActionText = await sendQuery(driver, mode, quiet, timeoutMs);
+      const preAction = await sendQuery(driver, mode, quiet, timeoutMs);
 
       if (stream) { emitState('researching'); }
       verbose('Waiting for Deep Research response...', isVerbose);
@@ -475,7 +482,7 @@ export const deepResearchCommand = defineCommand({
         timeout: timeoutMs,
         quiet,
         skipStartPhase: isFollowUpOrRefresh,
-        preActionText: isFollowUpOrRefresh ? preActionText : undefined,
+        preAction: isFollowUpOrRefresh ? preAction : undefined,
       });
 
       const chatId = resolveChatId(driver, mode, quiet);

--- a/src/core/chatgpt-driver.ts
+++ b/src/core/chatgpt-driver.ts
@@ -17,7 +17,7 @@ import { assertValidChatId, CHATGPT_BASE_URL, conversationLinkById, conversation
 
 import type { ConversationItem, ConversationMessage, DeepResearchExportFormat, ProjectItem, WaitForResponseOptions, WaitForResponseResult } from './chatgpt-types.js';
 import { attachFiles as attachFilesImpl, attachGitHubRepo as attachGitHubRepoImpl, attachGoogleDriveFile as attachGoogleDriveFileImpl, enableAgentMode as enableAgentModeImpl } from './driver/attachments.js';
-import { copyDeepResearchContent as copyDRContent, exportDeepResearch as exportDR, getDeepResearchResponse as getDRResponse, navigateToDeepResearch as navToDR, refreshDeepResearch as refreshDR, sendDeepResearchFollowUp as sendDRFollowUp, sendDeepResearchMessage as sendDRMsg, waitForDeepResearchResponse as waitForDRResponse } from './driver/deep-research.js';
+import { copyDeepResearchContent as copyDRContent, type DeepResearchPreActionState, exportDeepResearch as exportDR, getDeepResearchResponse as getDRResponse, navigateToDeepResearch as navToDR, refreshDeepResearch as refreshDR, sendDeepResearchFollowUp as sendDRFollowUp, sendDeepResearchMessage as sendDRMsg, waitForDeepResearchResponse as waitForDRResponse } from './driver/deep-research.js';
 import { clickReadySendButton, delay, isTimeoutError, POLL_INTERVAL_MS } from './driver/helpers.js';
 import { getAssistantMessageCount as getAssistantMsgCount, getLastResponse as getLastResp, waitForResponse as waitForResp } from './driver/response-handler.js';
 import { EFFORT_LABEL_CANDIDATES, MODEL_EFFORT_LEVELS, resolveModelCategory } from './model-config.js';
@@ -108,7 +108,7 @@ export class ChatGPTDriver {
     text: string,
     quiet = false,
     deadline?: number,
-  ): Promise<string> {
+  ): Promise<DeepResearchPreActionState> {
     await this.navigateToChat(chatId, quiet);
     return sendDRFollowUp(this.page, text, { quiet, deadline });
   }
@@ -117,7 +117,7 @@ export class ChatGPTDriver {
     chatId: string,
     quiet = false,
     deadline?: number,
-  ): Promise<string> {
+  ): Promise<DeepResearchPreActionState> {
     await this.navigateToChat(chatId, quiet);
     return refreshDR(this.page, { quiet, deadline });
   }
@@ -130,7 +130,7 @@ export class ChatGPTDriver {
     timeout?: number;
     quiet?: boolean;
     skipStartPhase?: boolean;
-    preActionText?: string;
+    preAction?: DeepResearchPreActionState;
   }): Promise<WaitForResponseResult> {
     return waitForDRResponse(this.page, options);
   }

--- a/src/core/driver/deep-research.ts
+++ b/src/core/driver/deep-research.ts
@@ -12,7 +12,7 @@ import type { DeepResearchExportFormat, WaitForResponseResult } from '../chatgpt
 import { progress } from '../output-handler.js';
 import { registerCleanup } from '../shutdown.js';
 
-import { DEFAULT_TIMEOUT_MS, computeIframeWaitDeadline, computePhaseDeadline, delay, isFrameDetachedError, isTimeoutError, POLL_INTERVAL_MS } from './helpers.js';
+import { DEFAULT_TIMEOUT_MS, clickReadySendButton, computeIframeWaitDeadline, computePhaseDeadline, delay, isFrameDetachedError, isTimeoutError, POLL_INTERVAL_MS } from './helpers.js';
 
 // ── Navigation ──────────────────────────────────────────────
 
@@ -45,23 +45,47 @@ export async function sendDeepResearchMessage(page: Page, text: string): Promise
   await sendBtn.click();
 }
 
+/**
+ * Snapshot of iframe state captured immediately before a DR action so the
+ * wait logic can disambiguate stale UI from fresh signals.  `hasExport` is
+ * key for follow-ups: the previous report's export button is typically
+ * visible on entry, so we initialise the polling state to "transition not
+ * yet observed" and require seeing the export button absent during polling
+ * before treating any later visible-export as completion.
+ */
+export interface DeepResearchPreActionState {
+  text: string;
+  hasExport: boolean;
+}
+
+async function snapshotPreActionState(page: Page): Promise<DeepResearchPreActionState> {
+  const [text, hasExport] = await Promise.all([
+    getDeepResearchResponse(page),
+    hasDeepResearchExportButton(page),
+  ]);
+  return { text, hasExport };
+}
+
 export async function sendDeepResearchFollowUp(
   page: Page,
   text: string,
   opts: { quiet?: boolean; deadline?: number },
-): Promise<string> {
+): Promise<DeepResearchPreActionState> {
   const { quiet = false, deadline } = opts;
 
   await waitForDeepResearchFrame(page, deadline);
 
-  const preActionText = await getDeepResearchResponse(page);
+  const preAction = await snapshotPreActionState(page);
 
   const input = page.locator(SELECTORS.PROMPT_INPUT);
   await input.fill(text);
 
-  const sendBtn = page.locator(SELECTORS.SEND_BUTTON_ENABLED);
+  // Reuse the regular-chat send-button helper which checks width/height,
+  // disabled, and aria-disabled before clicking.  The previous implementation
+  // hand-rolled `:not([disabled])` + `force: true`, which silently no-op'd
+  // when the button was still aria-disabled (React enable not yet flushed).
   try {
-    await sendBtn.waitFor({ state: 'visible', timeout: 5_000 });
+    await clickReadySendButton(page, SELECTORS.SEND_BUTTON_ENABLED, 5_000);
   } catch (e: unknown) {
     if (isTimeoutError(e)) {
       throw new Error(
@@ -70,18 +94,17 @@ export async function sendDeepResearchFollowUp(
     }
     throw e;
   }
-  await sendBtn.click({ force: true });
   progress('Follow-up sent', quiet);
-  return preActionText;
+  return preAction;
 }
 
 export async function refreshDeepResearch(
   page: Page,
   opts: { quiet?: boolean; deadline?: number },
-): Promise<string> {
+): Promise<DeepResearchPreActionState> {
   const contentFrame = await waitForDeepResearchFrame(page, opts.deadline);
 
-  const preActionText = await getDeepResearchResponse(page);
+  const preAction = await snapshotPreActionState(page);
 
   const updateBtn = contentFrame.locator(SELECTORS.DEEP_RESEARCH_UPDATE_BUTTON);
   try {
@@ -96,7 +119,7 @@ export async function refreshDeepResearch(
   }
   await updateBtn.first().scrollIntoViewIfNeeded();
   await updateBtn.first().click({ force: true });
-  return preActionText;
+  return preAction;
 }
 
 // ── Response extraction ─────────────────────────────────────
@@ -125,18 +148,73 @@ export async function getDeepResearchResponse(page: Page): Promise<string> {
 
 // ── Wait for completion ─────────────────────────────────────
 
+/** Result of the stop-detect phase. */
+interface StopDetectResult {
+  researchStarted: boolean;
+  exportAbsentObserved: boolean;
+}
+
+async function detectResearchStart(
+  page: Page,
+  deadline: number,
+  quiet: boolean,
+  initialExportAbsentObserved: boolean,
+): Promise<StopDetectResult> {
+  // Phase 2: Wait for research to start (stop button appears in iframe).
+  // While we wait, also watch for the export button transitioning to absent;
+  // a follow-up whose research finishes inside this window may never expose
+  // the stop button to phase 4 polling, but the export disappearance still
+  // marks a confirmed fresh-completion signal.
+  const STOP_DETECT_MS = 60_000;
+  const stopDetectDeadline = computePhaseDeadline(Date.now(), deadline, STOP_DETECT_MS);
+  let exportAbsentObserved = initialExportAbsentObserved;
+  while (Date.now() < stopDetectDeadline) {
+    await delay(POLL_INTERVAL_MS * 5);
+    const [stopVisible, exportVisible] = await Promise.all([
+      hasDeepResearchStopButton(page),
+      exportAbsentObserved ? Promise.resolve(true) : hasDeepResearchExportButton(page),
+    ]);
+    if (stopVisible) {
+      progress('Researching...', quiet);
+      return { researchStarted: true, exportAbsentObserved: true };
+    }
+    if (!exportVisible) {
+      exportAbsentObserved = true;
+    }
+  }
+  progress('Stop button not observed, checking for report...', quiet);
+  return { researchStarted: false, exportAbsentObserved };
+}
+
+async function waitForResearchEnd(page: Page, deadline: number, quiet: boolean): Promise<void> {
+  let lastLoggedAt = Date.now();
+  while (Date.now() < deadline) {
+    await delay(POLL_INTERVAL_MS * 5);
+    if (!await hasDeepResearchStopButton(page)) {
+      progress('Research phase complete, waiting for report...', quiet);
+      return;
+    }
+    const now = Date.now();
+    if (now - lastLoggedAt > 30_000) {
+      progress('Still researching...', quiet);
+      lastLoggedAt = now;
+    }
+  }
+}
+
 export async function waitForDeepResearchResponse(
   page: Page,
   options: {
     timeout?: number;
     quiet?: boolean;
     skipStartPhase?: boolean;
-    preActionText?: string;
+    preAction?: DeepResearchPreActionState;
   },
 ): Promise<WaitForResponseResult> {
   const timeout = options.timeout ?? DEFAULT_TIMEOUT_MS;
   const quiet = options.quiet ?? false;
-  const preActionText = options.preActionText ?? '';
+  const preActionText = options.preAction?.text ?? '';
+  const preActionHasExport = options.preAction?.hasExport ?? false;
 
   progress('Waiting for Deep Research response...', quiet);
 
@@ -147,42 +225,21 @@ export async function waitForDeepResearchResponse(
     await clickDeepResearchStart(page, deadline, quiet);
   }
 
-  // Phase 2: Wait for research to start (stop button appears in iframe).
-  const STOP_DETECT_MS = 60_000;
-  const stopDetectDeadline = computePhaseDeadline(Date.now(), deadline, STOP_DETECT_MS);
-  let researchStarted = false;
-  while (Date.now() < stopDetectDeadline) {
-    await delay(POLL_INTERVAL_MS * 5);
-    if (await hasDeepResearchStopButton(page)) {
-      researchStarted = true;
-      progress('Researching...', quiet);
-      break;
-    }
-  }
+  // Phase 2: Wait for research to start.
+  const { researchStarted, exportAbsentObserved } = await detectResearchStart(
+    page,
+    deadline,
+    quiet,
+    !preActionHasExport,
+  );
 
-  if (!researchStarted) {
-    progress('Stop button not observed, checking for report...', quiet);
-  }
-
-  // Phase 3: Wait for research to complete (stop button disappears)
+  // Phase 3: Wait for research to complete (stop button disappears).
   if (researchStarted) {
-    let lastLoggedAt = Date.now();
-    while (Date.now() < deadline) {
-      await delay(POLL_INTERVAL_MS * 5);
-      if (!await hasDeepResearchStopButton(page)) {
-        progress('Research phase complete, waiting for report...', quiet);
-        break;
-      }
-      const now = Date.now();
-      if (now - lastLoggedAt > 30_000) {
-        progress('Still researching...', quiet);
-        lastLoggedAt = now;
-      }
-    }
+    await waitForResearchEnd(page, deadline, quiet);
   }
 
-  // Phase 4: Wait for the final report to render
-  return waitForDeepResearchReport(page, deadline, timeout, quiet, researchStarted, preActionText);
+  // Phase 4: Wait for the final report to render.
+  return waitForDeepResearchReport(page, deadline, timeout, quiet, researchStarted, preActionText, exportAbsentObserved);
 }
 
 // ── Copy & export ───────────────────────────────────────────
@@ -387,18 +444,37 @@ async function waitForDeepResearchFrame(page: Page, deadline?: number): Promise<
 
 // ── Private helpers ─────────────────────────────────────────
 
-async function hasDeepResearchStopButton(page: Page): Promise<boolean> {
+async function hasVisibleDRControl(page: Page, selector: string): Promise<boolean> {
   const contentFrame = getDeepResearchContentFrame(page);
   if (!contentFrame) {
     return false;
   }
   try {
-    const count = await contentFrame.locator(SELECTORS.DEEP_RESEARCH_STOP_BUTTON).count();
-    return count > 0;
+    const locator = contentFrame.locator(selector);
+    const count = await locator.count();
+    // Visibility check matters: the stop button can linger in the DOM
+    // (hidden) after research completes, and the export button only
+    // becomes visible once the final report is rendered.  A `count() > 0`
+    // check is not enough.  Iterate over all matches so a hidden stale
+    // element earlier in the DOM does not mask a later visible control.
+    for (let i = 0; i < count; i++) {
+      if (await locator.nth(i).isVisible()) {
+        return true;
+      }
+    }
+    return false;
   } catch (error: unknown) {
     if (isFrameDetachedError(error)) { return false; }
     throw error;
   }
+}
+
+async function hasDeepResearchStopButton(page: Page): Promise<boolean> {
+  return hasVisibleDRControl(page, SELECTORS.DEEP_RESEARCH_STOP_BUTTON);
+}
+
+async function hasDeepResearchExportButton(page: Page): Promise<boolean> {
+  return hasVisibleDRControl(page, SELECTORS.DEEP_RESEARCH_EXPORT_BUTTON);
 }
 
 async function clickDeepResearchStart(
@@ -451,7 +527,8 @@ async function waitForDeepResearchReport(
   timeout: number,
   quiet: boolean,
   seenStopButton: boolean,
-  preActionText = '',
+  preActionText: string,
+  exportAbsentObserved: boolean,
 ): Promise<WaitForResponseResult> {
   const initialText = await getDeepResearchResponse(page);
 
@@ -463,67 +540,53 @@ async function waitForDeepResearchReport(
     return { text: initialText, completed: true };
   }
 
-  return pollForDeepResearchReport(page, deadline, timeout, quiet, seenStopButton, initialText, preActionText);
+  return pollForDeepResearchReport(page, deadline, timeout, quiet, seenStopButton, preActionText, exportAbsentObserved);
 }
 
 export interface ReportPollState {
-  stableCount: number;
-  previousText: string;
-  sawTransition: boolean;
+  /**
+   * True once `hasExport=false` has been observed since the action was sent
+   * (during the detect window, the research-end wait, or polling).  The
+   * export button is part of the final-report UI, so a confirmed absence is
+   * the only reliable proof that any later `hasExport=true` reflects a
+   * freshly rendered report rather than a stale button from the previous run.
+   */
+  exportObservedAbsent: boolean;
 }
 
 /**
  * Evaluate a single poll iteration for DR report readiness.
+ *
+ * Completion is gated on one of:
+ *   1. The export button is visible AND `state.exportObservedAbsent` is
+ *      true — only the final report exposes the export menu, and the
+ *      observed-absent flag confirms the signal is fresh.
+ *   2. The stop button cycle (`seenStopButton` true) completed and text
+ *      now differs from `preActionText` — the cycle "stop button appeared
+ *      then disappeared" only completes once the final report has rendered.
  *
  * @returns The final report text if complete, or `null` to keep polling.
  */
 export function evaluateReportPoll(
   text: string,
   hasStop: boolean,
+  hasExport: boolean,
   seenStopButton: boolean,
   preActionText: string,
   state: ReportPollState,
 ): string | null {
-  const STABLE_THRESHOLD = 3;
-
-  if (hasStop) {
-    state.sawTransition = true;
-    state.stableCount = 0;
+  if (!hasExport) {
+    state.exportObservedAbsent = true;
+  }
+  if (hasStop || text.length === 0) {
     return null;
   }
-  if (text.length === 0) {
-    state.sawTransition = true;
-    state.stableCount = 0;
-    state.previousText = '';
-    return null;
+  if (hasExport && state.exportObservedAbsent) {
+    return text;
   }
-  if (text !== preActionText) {
-    state.sawTransition = true;
-  }
-  // Still showing the pre-action text with no transition — keep waiting.
-  if (!seenStopButton && !state.sawTransition && text === preActionText) {
-    state.stableCount = 0;
-    return null;
-  }
-  // Stop button was seen → research cycle completed; any new text is final.
   if (seenStopButton && text !== preActionText) {
     return text;
   }
-  // Stop button was seen but text is still the pre-action content → keep waiting.
-  if (seenStopButton && text === preActionText && preActionText.length > 0) {
-    state.stableCount = 0;
-    return null;
-  }
-  // Stop button was NOT seen → require stability before declaring complete.
-  if (text === state.previousText) {
-    state.stableCount++;
-    if (state.stableCount >= STABLE_THRESHOLD) {
-      return text;
-    }
-  } else {
-    state.stableCount = 0;
-  }
-  state.previousText = text;
   return null;
 }
 
@@ -533,24 +596,18 @@ async function pollForDeepResearchReport(
   timeout: number,
   quiet: boolean,
   seenStopButton: boolean,
-  initialText: string,
   preActionText: string,
+  exportAbsentObserved: boolean,
 ): Promise<WaitForResponseResult> {
-  // When the stop button was observed, the research cycle is confirmed complete,
-  // so the first non-empty changed text is the final report.
-  // When the stop button was NOT observed (skipped or missed), we require
-  // consecutive identical reads to avoid returning a mid-generation report.
-  const state: ReportPollState = {
-    stableCount: 0,
-    previousText: initialText,
-    sawTransition: false,
-  };
+  const state: ReportPollState = { exportObservedAbsent: exportAbsentObserved };
 
   while (Date.now() < deadline) {
     await delay(POLL_INTERVAL_MS * 5);
     const hasStop = await hasDeepResearchStopButton(page);
-    const text = hasStop ? '' : await getDeepResearchResponse(page);
-    const result = evaluateReportPoll(text, hasStop, seenStopButton, preActionText, state);
+    const [hasExport, text] = hasStop
+      ? [false, '']
+      : await Promise.all([hasDeepResearchExportButton(page), getDeepResearchResponse(page)]);
+    const result = evaluateReportPoll(text, hasStop, hasExport, seenStopButton, preActionText, state);
     if (result !== null) {
       progress('Response complete', quiet);
       return { text: result, completed: true };

--- a/tests/dr-report-poll.test.ts
+++ b/tests/dr-report-poll.test.ts
@@ -4,91 +4,118 @@ import { type ReportPollState, evaluateReportPoll } from '../src/core/driver/dee
 
 describe('evaluateReportPoll', () => {
   function makeState(overrides: Partial<ReportPollState> = {}): ReportPollState {
-    return { stableCount: 0, previousText: '', sawTransition: false, ...overrides };
+    return { exportObservedAbsent: false, ...overrides };
   }
 
   it('returns null when stop button is visible', () => {
     const state = makeState();
-    const result = evaluateReportPoll('some text', true, false, '', state);
+    const result = evaluateReportPoll('some text', true, false, false, '', state);
     expect(result).toBeNull();
-    expect(state.sawTransition).toBe(true);
-    expect(state.stableCount).toBe(0);
   });
 
   it('returns null when text is empty', () => {
     const state = makeState();
-    const result = evaluateReportPoll('', false, false, 'pre', state);
+    const result = evaluateReportPoll('', false, false, false, 'pre', state);
     expect(result).toBeNull();
-    expect(state.sawTransition).toBe(true);
-    expect(state.previousText).toBe('');
   });
 
   it('returns text immediately when seenStopButton and text differs from preActionText', () => {
-    const state = makeState({ sawTransition: true });
-    const result = evaluateReportPoll('final report', false, true, 'pre-action', state);
+    const state = makeState();
+    const result = evaluateReportPoll('final report', false, false, true, 'pre-action', state);
     expect(result).toBe('final report');
   });
 
-  it('returns null when seenStopButton but text equals preActionText and resets stableCount', () => {
-    const state = makeState({ sawTransition: true, stableCount: 2 });
-    const result = evaluateReportPoll('pre-action', false, true, 'pre-action', state);
+  it('returns null when seenStopButton but text equals preActionText', () => {
+    const state = makeState();
+    const result = evaluateReportPoll('pre-action', false, false, true, 'pre-action', state);
     expect(result).toBeNull();
-    expect(state.stableCount).toBe(0);
   });
 
   it('does not return stale preActionText via stability check when seenStopButton is true', () => {
-    const state = makeState({
-      sawTransition: true,
-      previousText: 'pre-action',
-      stableCount: 0,
-    });
+    const state = makeState();
     // Call multiple times with text === preActionText and seenStopButton=true.
-    // Every call must return null — the stability check must never promote stale text.
+    // Every call must return null — the algorithm must never promote stale text.
     for (let i = 0; i < 5; i++) {
-      const result = evaluateReportPoll('pre-action', false, true, 'pre-action', state);
+      const result = evaluateReportPoll('pre-action', false, false, true, 'pre-action', state);
       expect(result).toBeNull();
-      expect(state.stableCount).toBe(0);
     }
   });
 
   it('returns null when no transition and text equals preActionText (no stop button)', () => {
-    const state = makeState({ sawTransition: false });
-    const result = evaluateReportPoll('pre-action', false, false, 'pre-action', state);
+    const state = makeState();
+    const result = evaluateReportPoll('pre-action', false, false, false, 'pre-action', state);
     expect(result).toBeNull();
-    expect(state.stableCount).toBe(0);
   });
 
-  it('increments stableCount on consecutive identical reads', () => {
-    const state = makeState({ sawTransition: true, previousText: 'report' });
-    const result = evaluateReportPoll('report', false, false, 'pre', state);
+  it('returns text immediately when no stale export was present at action time', () => {
+    // pollForDeepResearchReport seeds exportObservedAbsent from the caller, so
+    // initial calls and follow-ups whose previous report had no export visible
+    // start with the flag true.  Research that finishes faster than the 60s
+    // stop-detect window must still complete on the first poll where
+    // hasExport=true.
+    const state = makeState({ exportObservedAbsent: true });
+    const result = evaluateReportPoll('final report', false, true, false, '', state);
+    expect(result).toBe('final report');
+  });
+
+  it('completes follow-up via export only after observed disappearance', () => {
+    // Follow-up/refresh: the previous report's export button may still be
+    // visible at start.  exportObservedAbsent is false initially; we only
+    // trust hasExport=true after observing hasExport=false at least once.
+    const state = makeState();
+    expect(evaluateReportPoll('plan text', false, false, false, 'old report', state)).toBeNull();
+    expect(state.exportObservedAbsent).toBe(true);
+    const result = evaluateReportPoll('new report', false, true, false, 'old report', state);
+    expect(result).toBe('new report');
+  });
+
+  it('completes a refresh with identical regenerated text via export transition', () => {
+    // Refresh / follow-up that regenerates identical report text must still
+    // complete: the observed export disappearance + reappearance proves a
+    // fresh render cycle even when the text equals preActionText.
+    const state = makeState();
+    expect(evaluateReportPoll('plan text', false, false, false, 'old report', state)).toBeNull();
+    expect(state.exportObservedAbsent).toBe(true);
+    const result = evaluateReportPoll('old report', false, true, false, 'old report', state);
+    expect(result).toBe('old report');
+  });
+
+  it('does NOT return text on stale export visible from a previous report', () => {
+    // Regression for the follow-up/refresh false-positive: the previous
+    // report's export button is still visible at the start of the new run.
+    // Without observing it disappear, we cannot trust the export signal.
+    const state = makeState();
+    for (let i = 0; i < 5; i++) {
+      const result = evaluateReportPoll('new plan text', false, true, false, 'old report', state);
+      expect(result).toBeNull();
+    }
+    expect(state.exportObservedAbsent).toBe(false);
+  });
+
+  it('records exportObservedAbsent the first time hasExport is observed false', () => {
+    const state = makeState();
+    expect(state.exportObservedAbsent).toBe(false);
+    evaluateReportPoll('text', false, false, false, 'pre', state);
+    expect(state.exportObservedAbsent).toBe(true);
+  });
+
+  it('does NOT return text via stability alone without seenStopButton or export visibility', () => {
+    // Regression for the bug where the previous implementation auto-
+    // completed after STABLE_THRESHOLD identical reads.  On a first DR
+    // call preActionText is empty, so plan text would falsely satisfy
+    // the stability check and be returned as the final report.
+    const state = makeState();
+    for (let i = 0; i < 10; i++) {
+      const result = evaluateReportPoll('plan...', false, false, false, '', state);
+      expect(result).toBeNull();
+    }
+  });
+
+  it('treats hasStop as authoritative — never returns text even with hasExport', () => {
+    // If the stop button is currently visible, research is still in
+    // progress regardless of any other signal.
+    const state = makeState({ exportObservedAbsent: true });
+    const result = evaluateReportPoll('text', true, true, true, 'pre', state);
     expect(result).toBeNull();
-    expect(state.stableCount).toBe(1);
-  });
-
-  it('returns text after STABLE_THRESHOLD (3) consecutive identical reads', () => {
-    const state = makeState({ sawTransition: true, previousText: 'report', stableCount: 1 });
-
-    // 2nd consecutive match
-    const r1 = evaluateReportPoll('report', false, false, 'pre', state);
-    expect(r1).toBeNull();
-    expect(state.stableCount).toBe(2);
-
-    // 3rd consecutive match → threshold reached
-    const r2 = evaluateReportPoll('report', false, false, 'pre', state);
-    expect(r2).toBe('report');
-  });
-
-  it('resets stableCount when text changes', () => {
-    const state = makeState({ sawTransition: true, previousText: 'old', stableCount: 2 });
-    const result = evaluateReportPoll('new', false, false, 'pre', state);
-    expect(result).toBeNull();
-    expect(state.stableCount).toBe(0);
-    expect(state.previousText).toBe('new');
-  });
-
-  it('marks sawTransition when text differs from preActionText', () => {
-    const state = makeState({ sawTransition: false });
-    evaluateReportPoll('new text', false, false, 'pre-action', state);
-    expect(state.sawTransition).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes three bugs in Deep Research follow-up / refresh that surfaced via live testing.

- **Send button never click registers**: `sendDeepResearchFollowUp` used a hand-rolled `:not([disabled])` + `force: true` click that silently no-op'd when the button was still aria-disabled. Now reuses `clickReadySendButton`, which validates width/height, disabled, and aria-disabled before clicking.
- **Stale hidden stop / export buttons mask the real ones**: `hasDeepResearchStopButton` only checked `count() > 0`, so a hidden stale element earlier in the DOM could mask a later visible control. The new `hasVisibleDRControl` iterates `nth(i).isVisible()` over all matches; a parallel `hasDeepResearchExportButton` reuses the same helper.
- **Completion detection promotes plan text as the final report**: the prior `evaluateReportPoll` had a stability fallback that auto-completed after N identical reads — on a first DR call (where `preActionText` is empty) plan text could falsely satisfy this. Completion now requires either a fresh export-button transition (`exportObservedAbsent`) plus the export visible, or a stop-button cycle plus text changed from `preActionText`. The pre-action snapshot of `{text, hasExport}` lets us seed `exportObservedAbsent=true` for runs without a prior export so super-fast completions don't hang under the default unlimited timeout.

## Test plan

- [x] Unit tests: `tests/dr-report-poll.test.ts` covers stop-cycle, export-only, refresh-with-identical-text, stale-export false-positive, and a fast-completion case.
- [x] `npm run lint && npm run typecheck && npm test` — all 449 tests pass.
- [x] Live Chrome test — initial DR + follow-up DR with `--sync` both return `partial: false` with correct content. Test conversations deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/cavendish/pull/233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable completion detection so research results display only when fully updated, preventing stale content or stale export controls.
  * Harder checks for stop/export controls to avoid false positives and silent no-op submissions.
* **Tests**
  * Updated tests to validate export-presence transitions and to prevent regressions where prior "stability" heuristics could prematurely finish research.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->