### PR TITLE
fix(jobs): recover hung workers and emit JSON validation errors

### DIFF
--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -7,7 +7,7 @@ import { runJobRunnerOrExit } from '../core/jobs/runner.js';
 import { readJobError, readJobResult, readJob, listJobs } from '../core/jobs/store.js';
 import type { JobRecord } from '../core/jobs/types.js';
 import { runJobWorkerOrExit } from '../core/jobs/worker.js';
-import { fail, failStructured, jsonRaw, progress, text, validateFormat } from '../core/output-handler.js';
+import { fail, failStructured, failValidation, jsonRaw, progress, text, validateFormat } from '../core/output-handler.js';
 
 const JOBS_ARGS = {
   ...GLOBAL_ARGS,
@@ -265,7 +265,7 @@ export const waitCommand = defineCommand({
     }, format)) { return; }
     const timeoutSec = args.timeout !== undefined ? Number(args.timeout) : 0;
     if (!Number.isFinite(timeoutSec) || timeoutSec < 0) {
-      fail(`--timeout must be a non-negative number, got "${String(args.timeout)}"`);
+      failValidation(`--timeout must be a non-negative number, got "${String(args.timeout)}"`, format);
       return;
     }
     const pollIntervalMs = parsePollIntervalMs(args.poll, format);

--- a/src/core/jobs/store.ts
+++ b/src/core/jobs/store.ts
@@ -239,11 +239,16 @@ function staleRunningReason(job: JobRecord, nowMs: number): string | undefined {
   if (job.status !== 'running') {
     return undefined;
   }
-  if (job.workerPid !== undefined) {
-    return !isWorkerPidAlive(job.workerPid)
-      ? `worker process ${String(job.workerPid)} is no longer running`
-      : undefined;
+  if (job.workerPid !== undefined && !isWorkerPidAlive(job.workerPid)) {
+    return `worker process ${String(job.workerPid)} is no longer running`;
   }
+  // Even when the PID is alive we still apply the no-progress check.  A live
+  // PID does not prove activity — the worker can hang on a network call,
+  // locked resource, or infinite loop.  Long-running Deep Research is not a
+  // false-positive risk because the worker emits "Still researching..."
+  // progress every 30s; appendStderrEvent writes that line to events.ndjson,
+  // refreshing its mtime which `latestJobProgressMs` reads.  A worker silent
+  // for 30 minutes has missed ~60 heartbeats and is genuinely wedged.
   const progressMs = latestJobProgressMs(job);
   if (progressMs !== undefined && nowMs - progressMs >= STALE_RUNNING_JOB_MS) {
     return `no progress for ${String(Math.round((nowMs - progressMs) / 1000))}s`;
@@ -299,6 +304,15 @@ export function readNextQueuedJob(): JobRecord | undefined {
     }
     const staleReason = staleRunningReason(job, nowMs);
     if (staleReason !== undefined) {
+      // We deliberately do NOT SIGKILL the prior workerPid even when it's
+      // still alive: PIDs are reused by the kernel after process exit, so
+      // a worker that crashed without updating job state may have its PID
+      // assigned to an unrelated user process by the time recovery runs.
+      // Killing-by-PID without an OS-portable identity check (ps/tasklist
+      // wrapper) risks terminating that unrelated process.  In the rare
+      // case the original worker is still genuinely active, the next
+      // worker's Playwright/Chrome interactions will surface any real
+      // conflict via the existing error paths.
       const recovered = recoverStaleRunningJob(job, staleReason);
       if (recovered.status === 'queued') {
         return recovered;

--- a/tests/jobs-command.test.ts
+++ b/tests/jobs-command.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let failStructuredMock: ReturnType<typeof vi.fn>;
+let failValidationMock: ReturnType<typeof vi.fn>;
 let jsonRawMock: ReturnType<typeof vi.fn>;
 let progressMock: ReturnType<typeof vi.fn>;
 
@@ -49,11 +50,13 @@ vi.mock('../src/core/jobs/runner.js', () => ({
 
 vi.mock('../src/core/output-handler.js', () => {
   failStructuredMock = vi.fn();
+  failValidationMock = vi.fn();
   jsonRawMock = vi.fn();
   progressMock = vi.fn();
   return {
     fail: vi.fn(),
     failStructured: failStructuredMock,
+    failValidation: failValidationMock,
     jsonRaw: jsonRawMock,
     progress: progressMock,
     text: vi.fn(),
@@ -339,6 +342,36 @@ describe('jobs command', () => {
         partial: true,
       }),
     );
+  });
+
+  it('emits a JSON validation error when --timeout is invalid and --format=json', async () => {
+    const { jobsCommand } = await import('../src/commands/jobs.js');
+    const subCommands = jobsCommand.subCommands as unknown as { wait?: RunnableCommand };
+    const waitCommand = subCommands.wait;
+    const run = waitCommand?.run;
+    if (waitCommand === undefined || run === undefined) {
+      throw new Error('jobsCommand.subCommands.wait.run is undefined');
+    }
+
+    await run({
+      args: {
+        _: [],
+        jobId: 'job-id',
+        timeout: 'not-a-number',
+        format: 'json',
+        quiet: false,
+        verbose: false,
+      } as never,
+      rawArgs: [],
+      cmd: waitCommand,
+    });
+
+    expect(failValidationMock).toHaveBeenCalledTimes(1);
+    expect(failValidationMock).toHaveBeenCalledWith(
+      expect.stringContaining('--timeout must be a non-negative number'),
+      'json',
+    );
+    expect(jsonRawMock).not.toHaveBeenCalled();
   });
 
   it('fails jobs wait with a no-progress error when a running job has stale updatedAt', async () => {

--- a/tests/jobs-store.test.ts
+++ b/tests/jobs-store.test.ts
@@ -187,8 +187,42 @@ describe('job store', () => {
     }
   });
 
-  it('does not recover a stale running job while its worker pid is still alive', async () => {
+  it('does not recover a running job while its worker pid is alive and recently progressed', async () => {
     const { createJob, getJobFilePath, readJob, readNextQueuedJob, updateJob } = await importWithMockedHome();
+    const job = createJob({
+      kind: 'deep-research',
+      argv: ['deep-research', 'topic'],
+    });
+    const runningJob = updateJob(job.jobId, {
+      status: 'running',
+      workerPid: 12345,
+    });
+    writeFileSync(getJobFilePath(job.jobId), `${JSON.stringify({
+      ...runningJob,
+      updatedAt: '2026-03-14T00:00:00.000Z',
+    }, null, 2)}\n`);
+    // 5 minutes after last progress — well within the 30-minute threshold.
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(
+      new Date('2026-03-14T00:05:00.000Z').getTime(),
+    );
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    try {
+      const next = readNextQueuedJob();
+
+      expect(next).toBeUndefined();
+      expect(killSpy).toHaveBeenCalledWith(12345, 0);
+      expect(readJob(job.jobId)?.status).toBe('running');
+      expect(readJob(job.jobId)?.retryCount).toBe(0);
+      expect(readJob(job.jobId)?.workerPid).toBe(12345);
+    } finally {
+      killSpy.mockRestore();
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('recovers a stale running job when alive worker pid shows no progress', async () => {
+    const { createJob, getJobFilePath, readNextQueuedJob, updateJob } = await importWithMockedHome();
     const job = createJob({
       kind: 'deep-research',
       argv: ['deep-research', 'topic'],
@@ -209,11 +243,15 @@ describe('job store', () => {
     try {
       const next = readNextQueuedJob();
 
-      expect(next).toBeUndefined();
+      expect(next?.jobId).toBe(job.jobId);
+      expect(next?.status).toBe('queued');
+      expect(next?.retryCount).toBe(1);
+      expect(next?.lastRetryError).toContain('no progress');
+      expect(next?.workerPid).toBeUndefined();
+      // Liveness probe is allowed; a destructive signal must not be sent.
       expect(killSpy).toHaveBeenCalledWith(12345, 0);
-      expect(readJob(job.jobId)?.status).toBe('running');
-      expect(readJob(job.jobId)?.retryCount).toBe(0);
-      expect(readJob(job.jobId)?.workerPid).toBe(12345);
+      const destructiveCall = killSpy.mock.calls.find((call) => call[1] !== 0);
+      expect(destructiveCall).toBeUndefined();
     } finally {
       killSpy.mockRestore();
       nowSpy.mockRestore();


### PR DESCRIPTION
## Summary

- **`staleRunningReason` no longer skips the no-progress check when `workerPid` is alive**: a worker hung on a locked resource or infinite loop was never reclaimed. The 30-minute no-progress threshold runs regardless of PID liveness now. Long-running Deep Research is not a false-positive risk — the worker emits "Still researching…" every 30s, which `appendStderrEvent` writes to `events.ndjson`, refreshing the mtime read by `latestJobProgressMs`.
- **`cavendish wait --timeout=<bad> --format=json` now emits a JSON error**: previously it routed through `fail()` which always writes plain text, breaking JSON consumers. Switched to `failValidation` so the format selector is honoured.

We deliberately do not SIGKILL the prior PID during recovery: kernels reuse PIDs after process exit, and without a portable identity check (ps/tasklist wrapper) killing by stored PID risks terminating an unrelated user process.

## Test plan

- [x] `tests/jobs-store.test.ts` — new regression test covers alive-PID + no-progress recovery; the existing "alive PID does not recover" test was renamed and adjusted to use a recent `now` so it asserts the intended invariant (alive + recent progress → no recovery).
- [x] `tests/jobs-command.test.ts` — new test asserts `failValidation` is called with `'json'` when wait gets an invalid `--timeout`.
- [x] `npm run lint && npm run typecheck && npm test` — all 447 tests pass (1 skipped, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/toarupen/cavendish/pull/234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced job staleness detection to identify jobs without recent progress, even when the worker process remains active, improving job recovery reliability.
  * Improved timeout validation for the `jobs wait` subcommand with format-aware error messages that properly respect the specified output format (e.g., JSON) for better automation workflow integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->