### PR TITLE
Fix ChatGPT DOM drift and Pro stall handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cavendish",
-  "version": "2.1.2",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cavendish",
-      "version": "2.1.2",
+      "version": "2.1.4",
       "license": "ISC",
       "dependencies": {
         "citty": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cavendish",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "A Playwright-based CLI tool that automates ChatGPT's Web UI, enabling coding agents to query ChatGPT Pro models via a single shell command",
   "type": "module",
   "files": [

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -26,6 +26,7 @@ import {
   loadBaseline,
   saveBaseline,
   validateAllSelectors,
+  waitForReportReady,
 } from '../core/report.js';
 
 const REPORT_ARGS = {
@@ -100,6 +101,7 @@ export const reportCommand = defineCommand({
       const page = await browser.getPage(quiet);
 
       await ensureChatGptPage(page, quiet);
+      await waitForReportReady(page, quiet);
       const result = await buildReport(page, quiet);
 
       // Output

--- a/src/constants/selectors.ts
+++ b/src/constants/selectors.ts
@@ -63,9 +63,9 @@ export const SELECTORS = {
   THINKING_INDICATOR: '.agent-turn',
 
   // ── Thinking effort ────────────────────────────────────────
-  /** Composer footer actions container, or current-model action pill in the latest ChatGPT DOM */
+  /** Composer footer actions container, or current-model action pill wrapper in the latest ChatGPT DOM */
   COMPOSER_FOOTER_ACTIONS:
-    '[data-testid="composer-footer-actions"], form:has(#prompt-textarea) button.__composer-pill[aria-haspopup="menu"]',
+    '[data-testid="composer-footer-actions"], form:has(#prompt-textarea) span:has(> button.__composer-pill[aria-haspopup="menu"])',
 
   /** Thinking effort pill button in the composer footer */
   THINKING_EFFORT_PILL:

--- a/src/constants/selectors.ts
+++ b/src/constants/selectors.ts
@@ -63,9 +63,9 @@ export const SELECTORS = {
   THINKING_INDICATOR: '.agent-turn',
 
   // ── Thinking effort ────────────────────────────────────────
-  /** Container for composer footer action pills (model features) */
+  /** Composer footer actions container, or current-model action pill in the latest ChatGPT DOM */
   COMPOSER_FOOTER_ACTIONS:
-    '[data-testid="composer-footer-actions"], form:has(#prompt-textarea)',
+    '[data-testid="composer-footer-actions"], form:has(#prompt-textarea) button.__composer-pill[aria-haspopup="menu"]',
 
   /** Thinking effort pill button in the composer footer */
   THINKING_EFFORT_PILL:

--- a/src/constants/selectors.ts
+++ b/src/constants/selectors.ts
@@ -16,7 +16,8 @@ export const SELECTORS = {
 
   // ── Model selection ──────────────────────────────────────
   /** Button that opens the model picker dropdown */
-  MODEL_SELECTOR_BUTTON: '[data-testid="model-switcher-dropdown-button"]',
+  MODEL_SELECTOR_BUTTON:
+    '[data-testid="model-switcher-dropdown-button"], form:has(#prompt-textarea) button.__composer-pill[aria-haspopup="menu"]',
 
   /** Model picker dropdown menu */
   MODEL_MENU: '[role="menu"]',
@@ -63,10 +64,12 @@ export const SELECTORS = {
 
   // ── Thinking effort ────────────────────────────────────────
   /** Container for composer footer action pills (model features) */
-  COMPOSER_FOOTER_ACTIONS: '[data-testid="composer-footer-actions"]',
+  COMPOSER_FOOTER_ACTIONS:
+    '[data-testid="composer-footer-actions"], form:has(#prompt-textarea)',
 
   /** Thinking effort pill button in the composer footer */
-  THINKING_EFFORT_PILL: '[data-testid="composer-footer-actions"] button[aria-haspopup="menu"]',
+  THINKING_EFFORT_PILL:
+    '[data-testid="composer-footer-actions"] button[aria-haspopup="menu"], form:has(#prompt-textarea) button.__composer-pill[aria-haspopup="menu"]',
 
   /** Menu items inside the thinking effort dropdown */
   THINKING_EFFORT_MENUITEM: '[role="menuitemradio"]',
@@ -204,7 +207,8 @@ export const SELECTORS = {
 
   // ── GitHub integration ────────────────────────────────────
   /** GitHub pill button in composer footer (after GitHub is enabled) */
-  GITHUB_FOOTER_BUTTON: '[data-testid="composer-footer-actions"] button:has-text("GitHub")',
+  GITHUB_FOOTER_BUTTON:
+    '[data-testid="composer-footer-actions"] button:has-text("GitHub"), form:has(#prompt-textarea) button:has-text("GitHub")',
 
   /** Repository search input in the GitHub picker popover */
   GITHUB_REPO_SEARCH: 'input[placeholder="リポジトリを検索..."], input[placeholder="Search repositories..."]',

--- a/src/core/browser-manager.ts
+++ b/src/core/browser-manager.ts
@@ -337,9 +337,98 @@ export class BrowserManager {
     try {
       await this.connect(quiet);
     } catch {
+      this.cleanupSavedEndpointChrome(quiet);
+      this.cleanupProfileChromeProcesses(quiet);
       progress('CDP connection failed, launching new Chrome...', quiet);
       await this.launch(quiet);
     }
+  }
+
+  /**
+   * Stop the Chrome process referenced by the saved endpoint before launching
+   * a replacement. A reachable CDP port can still be unusable for Playwright
+   * (for example when Chrome rejects context-management commands), and leaving
+   * that process alive makes a new Chrome invocation reuse the same profile and
+   * endpoint.
+   */
+  private cleanupSavedEndpointChrome(quiet: boolean): void {
+    const endpoint = readCdpEndpoint();
+    const pid = endpoint?.pid ?? 0;
+    if (pid <= 0) {
+      return;
+    }
+    if (this.killOrphanChrome(pid, quiet)) {
+      this.removeStaleCdpEndpoint(pid, quiet);
+    }
+  }
+
+  private cleanupProfileChromeProcesses(quiet: boolean): void {
+    const pids = this.findChromePidsByProfileDir();
+    if (pids === null || pids.length === 0) {
+      return;
+    }
+    for (const pid of pids) {
+      this.killOrphanChrome(pid, quiet);
+    }
+  }
+
+  private findChromePidsByProfileDir(): number[] | null {
+    const scanner = this.resolveProfileProcessScanner();
+    if (!scanner) {
+      return null;
+    }
+    try {
+      const output = execFileSync(scanner.cmd, scanner.args, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 5_000,
+      });
+      return output
+        .split('\n')
+        .map((line) => parseInt(line.trim(), 10))
+        .filter((pid) => !isNaN(pid) && pid > 0);
+    } catch (error: unknown) {
+      const exitCode = (error as NodeJS.ErrnoException & { status?: number }).status;
+      if (scanner.noMatchExitCode !== null && exitCode === scanner.noMatchExitCode) {
+        return [];
+      }
+      return null;
+    }
+  }
+
+  private resolveProfileProcessScanner(): { cmd: string; args: string[]; noMatchExitCode: number | null } | null {
+    if (process.platform === 'win32') {
+      const systemRoot = process.env.SystemRoot ?? process.env.WINDIR ?? 'C:\\Windows';
+      const psPath = `${systemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
+      if (!existsSync(psPath)) {
+        return null;
+      }
+      const escapedDir = CHROME_PROFILE_DIR
+        .replaceAll('\\', '\\\\')
+        .replaceAll("'", "''")
+        .replaceAll('[', '[[]')
+        .replaceAll('%', '[%]')
+        .replaceAll('_', '[_]');
+      return {
+        cmd: psPath,
+        args: [
+          '-NoProfile', '-Command',
+          `Get-CimInstance Win32_Process -Filter "Name like '%chrome%' AND CommandLine like '%--user-data-dir=${escapedDir}%'" | Select-Object -ExpandProperty ProcessId`,
+        ],
+        noMatchExitCode: null,
+      };
+    }
+
+    const pgrepPath = ['/usr/bin/pgrep', '/bin/pgrep', '/sbin/pgrep'].find((p) => existsSync(p));
+    if (!pgrepPath) {
+      return null;
+    }
+    const escapedDir = CHROME_PROFILE_DIR.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return {
+      cmd: pgrepPath,
+      args: ['-fi', '--', `(chrome|chromium).*--user-data-dir=${escapedDir}( |$)`],
+      noMatchExitCode: 1,
+    };
   }
 
   /**

--- a/src/core/browser-manager.ts
+++ b/src/core/browser-manager.ts
@@ -48,6 +48,25 @@ const CDP_MAX_RETRIES = 3;
 const CDP_RETRY_INTERVAL_MS = 5_000;
 const CDP_FETCH_TIMEOUT_MS = 5_000;
 
+export function escapePowerShellWqlLikeLiteral(value: string): string {
+  return value
+    .replaceAll('\\', '\\\\')
+    .replaceAll("'", "''")
+    .replaceAll('[', '[[]')
+    .replaceAll('%', '[%]')
+    .replaceAll('_', '[_]')
+    .replaceAll('`', '``')
+    .replaceAll('$', '`$');
+}
+
+export function isRecoverableCdpRelaunchError(error: unknown): boolean {
+  if (error instanceof CavendishError && error.category === 'cdp_unavailable') {
+    return /CDP endpoint not found/i.test(error.message);
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return /Browser\.setDownloadBehavior|Browser context management is not supported|ECONNREFUSED|ECONNRESET|socket hang up|WebSocket.*(?:closed|failed|refused)|Target page, context or browser has been closed/i.test(message);
+}
+
 interface CdpEndpointData {
   url?: string;
   port: number;
@@ -336,9 +355,11 @@ export class BrowserManager {
   private async ensureConnected(quiet: boolean): Promise<void> {
     try {
       await this.connect(quiet);
-    } catch {
-      this.cleanupSavedEndpointChrome(quiet);
-      this.cleanupProfileChromeProcesses(quiet);
+    } catch (error: unknown) {
+      if (isRecoverableCdpRelaunchError(error)) {
+        this.cleanupSavedEndpointChrome(quiet);
+        this.cleanupProfileChromeProcesses(quiet);
+      }
       progress('CDP connection failed, launching new Chrome...', quiet);
       await this.launch(quiet);
     }
@@ -403,12 +424,7 @@ export class BrowserManager {
       if (!existsSync(psPath)) {
         return null;
       }
-      const escapedDir = CHROME_PROFILE_DIR
-        .replaceAll('\\', '\\\\')
-        .replaceAll("'", "''")
-        .replaceAll('[', '[[]')
-        .replaceAll('%', '[%]')
-        .replaceAll('_', '[_]');
+      const escapedDir = escapePowerShellWqlLikeLiteral(CHROME_PROFILE_DIR);
       return {
         cmd: psPath,
         args: [

--- a/src/core/driver/response-handler.ts
+++ b/src/core/driver/response-handler.ts
@@ -148,7 +148,7 @@ async function monitorResponse(
       return { text: snapshot.text, completed: true };
     }
 
-    assertNotStalled(started, now, lastActivityAt, stallTimeoutMs);
+    assertNotStalled(started, snapshot.stopButtonVisible, now, lastActivityAt, stallTimeoutMs);
 
     lastSnapshot = snapshot;
     await delay(POLL_INTERVAL_MS);
@@ -331,11 +331,12 @@ function isCompletedRepeatedFollowUp(
 
 function assertNotStalled(
   started: boolean,
+  stopButtonVisible: boolean,
   now: number,
   lastActivityAt: number,
   stallTimeoutMs: number,
 ): void {
-  if (!started || now - lastActivityAt < stallTimeoutMs) {
+  if (!started || stopButtonVisible || now - lastActivityAt < stallTimeoutMs) {
     return;
   }
 

--- a/src/core/report.ts
+++ b/src/core/report.ts
@@ -20,6 +20,7 @@ export const DOM_SNAPSHOT_FILE = join(CAVENDISH_DIR, 'dom-snapshot.json');
 export const SNAPSHOT_VERSION = 1;
 const FILE_MODE = 0o600;
 const MAX_DOM_ELEMENTS = 300;
+const REPORT_READY_TIMEOUT_MS = 10_000;
 
 // ── Types ─────────────────────────────────────────────────
 
@@ -121,6 +122,18 @@ export function categorizeSelector(name: string): SelectorCategory {
   if (HOMEPAGE_SELECTORS.has(name)) {return 'homepage';}
   if (AUTH_SELECTORS.has(name)) {return 'auth';}
   return 'contextual';
+}
+
+export async function waitForReportReady(
+  page: Page,
+  quiet: boolean,
+  timeout = REPORT_READY_TIMEOUT_MS,
+): Promise<void> {
+  try {
+    await page.locator(SELECTORS.PROMPT_INPUT).waitFor({ state: 'visible', timeout });
+  } catch (error: unknown) {
+    progress('Warning: prompt composer was not ready before report validation: ' + errorMessage(error), quiet);
+  }
 }
 
 // ── Selector validation ───────────────────────────────────
@@ -284,6 +297,7 @@ export function determineBroken(
   const baselineMisses = new Set(baseline?.newMisses ?? []);
   return selectors.filter((s) => {
     if (s.count > 0) {return false;}
+    if (isDeepResearchSelector(s.name as SelectorKey)) {return false;}
     return s.category === 'homepage' || baselineMisses.has(s.name);
   });
 }

--- a/tests/cdp-robustness.test.ts
+++ b/tests/cdp-robustness.test.ts
@@ -113,9 +113,9 @@ interface MinimalBrowser {
 }
 
 /** Mock child_process.spawn to return a fake Chrome process. */
-function mockSpawn(pid: number): void {
+function mockSpawn(pid: number, profilePids: number[] = []): void {
   vi.doMock('node:child_process', () => ({
-    execFileSync: (): string => '',
+    execFileSync: (): string => profilePids.map((profilePid) => String(profilePid)).join('\n'),
     spawn: (): { pid: number; unref: () => void; once: (evt: string, cb: () => void) => void } => ({
       pid,
       unref: (): void => { /* noop stub */ },
@@ -184,17 +184,18 @@ function stubProcessKill(killOverride?: (pid: number, signal?: NodeJS.Signals | 
  */
 async function importWithMocks(options: {
   fetchBehavior: (url: string, init?: RequestInit) => Promise<Response>;
-  connectBehavior?: 'success' | 'fail';
+  connectBehavior?: 'success' | 'fail' | 'fail-once';
   spawnPid?: number;
   endpointPid?: number;
   killOverride?: (pid: number, signal?: NodeJS.Signals | number) => true;
+  profilePids?: number[];
 }): Promise<{ BrowserManager: typeof import('../src/core/browser-manager.js').BrowserManager }> {
   vi.resetModules();
 
   const pid = options.spawnPid ?? 12345;
-  const connectFails = options.connectBehavior === 'fail';
+  let connectAttempts = 0;
 
-  mockSpawn(pid);
+  mockSpawn(pid, options.profilePids);
   mockFsForLaunch(options.endpointPid);
   mockOutputHandler();
 
@@ -206,6 +207,10 @@ async function importWithMocks(options: {
   vi.doMock('playwright-core', () => ({
     chromium: {
       connectOverCDP: (): Promise<MinimalBrowser> => {
+        connectAttempts += 1;
+        const connectFails =
+          options.connectBehavior === 'fail'
+          || (options.connectBehavior === 'fail-once' && connectAttempts === 1);
         if (connectFails) {
           return Promise.reject(new Error('connectOverCDP failed'));
         }
@@ -376,5 +381,38 @@ describe('launch() kills orphan Chrome on CDP failure (#136)', () => {
     await expect(bm.launch(true)).rejects.toThrow(/Failed to connect to Chrome via CDP/);
     // EPERM means Chrome is likely still running — do NOT remove endpoint
     expect(unlinkSyncCalls.length).toBe(0);
+  });
+
+  it('cleans up the current endpoint before relaunching after reconnect failure', async () => {
+    const { BrowserManager } = await importWithMocks({
+      fetchBehavior: (): Promise<Response> =>
+        Promise.resolve(new Response('{}', { status: 200 })),
+      connectBehavior: 'fail-once',
+      spawnPid: 33333,
+      endpointPid: 22222,
+    });
+
+    const bm = new BrowserManager();
+
+    await (bm as unknown as { ensureConnected(quiet: boolean): Promise<void> }).ensureConnected(true);
+
+    expect(processKillCalls.some((c) => c.pid === 22222)).toBe(true);
+    expect(unlinkSyncCalls.length).toBeGreaterThan(0);
+  });
+
+  it('cleans up Chrome processes for the profile when reconnect fails without an endpoint', async () => {
+    const { BrowserManager } = await importWithMocks({
+      fetchBehavior: (): Promise<Response> =>
+        Promise.resolve(new Response('{}', { status: 200 })),
+      connectBehavior: 'success',
+      spawnPid: 33333,
+      profilePids: [22222],
+    });
+
+    const bm = new BrowserManager();
+
+    await (bm as unknown as { ensureConnected(quiet: boolean): Promise<void> }).ensureConnected(true);
+
+    expect(processKillCalls.some((c) => c.pid === 22222)).toBe(true);
   });
 });

--- a/tests/cdp-robustness.test.ts
+++ b/tests/cdp-robustness.test.ts
@@ -185,6 +185,7 @@ function stubProcessKill(killOverride?: (pid: number, signal?: NodeJS.Signals | 
 async function importWithMocks(options: {
   fetchBehavior: (url: string, init?: RequestInit) => Promise<Response>;
   connectBehavior?: 'success' | 'fail' | 'fail-once';
+  connectErrorMessage?: string;
   spawnPid?: number;
   endpointPid?: number;
   killOverride?: (pid: number, signal?: NodeJS.Signals | number) => true;
@@ -212,7 +213,7 @@ async function importWithMocks(options: {
           options.connectBehavior === 'fail'
           || (options.connectBehavior === 'fail-once' && connectAttempts === 1);
         if (connectFails) {
-          return Promise.reject(new Error('connectOverCDP failed'));
+          return Promise.reject(new Error(options.connectErrorMessage ?? 'connectOverCDP failed'));
         }
         return Promise.resolve(stubBrowser);
       },
@@ -388,6 +389,8 @@ describe('launch() kills orphan Chrome on CDP failure (#136)', () => {
       fetchBehavior: (): Promise<Response> =>
         Promise.resolve(new Response('{}', { status: 200 })),
       connectBehavior: 'fail-once',
+      connectErrorMessage:
+        'browserType.connectOverCDP: Protocol error (Browser.setDownloadBehavior): Browser context management is not supported.',
       spawnPid: 33333,
       endpointPid: 22222,
     });
@@ -398,6 +401,25 @@ describe('launch() kills orphan Chrome on CDP failure (#136)', () => {
 
     expect(processKillCalls.some((c) => c.pid === 22222)).toBe(true);
     expect(unlinkSyncCalls.length).toBeGreaterThan(0);
+  });
+
+  it('does not kill the saved endpoint for generic reconnect failures', async () => {
+    const { BrowserManager } = await importWithMocks({
+      fetchBehavior: (): Promise<Response> =>
+        Promise.resolve(new Response('{}', { status: 200 })),
+      connectBehavior: 'fail-once',
+      connectErrorMessage: 'connectOverCDP failed',
+      spawnPid: 33333,
+      endpointPid: 22222,
+      profilePids: [22222],
+    });
+
+    const bm = new BrowserManager();
+
+    await (bm as unknown as { ensureConnected(quiet: boolean): Promise<void> }).ensureConnected(true);
+
+    expect(processKillCalls.some((c) => c.pid === 22222)).toBe(false);
+    expect(unlinkSyncCalls.length).toBe(0);
   });
 
   it('cleans up Chrome processes for the profile when reconnect fails without an endpoint', async () => {
@@ -414,5 +436,17 @@ describe('launch() kills orphan Chrome on CDP failure (#136)', () => {
     await (bm as unknown as { ensureConnected(quiet: boolean): Promise<void> }).ensureConnected(true);
 
     expect(processKillCalls.some((c) => c.pid === 22222)).toBe(true);
+  });
+});
+
+describe('PowerShell WQL escaping for Chrome profile scans', () => {
+  it('escapes WQL wildcard characters and PowerShell metacharacters', async () => {
+    mockOutputHandler();
+
+    const { escapePowerShellWqlLikeLiteral } = await import('../src/core/browser-manager.js');
+
+    expect(escapePowerShellWqlLikeLiteral(String.raw`C:\Users\o'hara[a]_%$` + '`')).toBe(
+      String.raw`C:\\Users\\o''hara[[]a][_][%]` + '`$``',
+    );
   });
 });

--- a/tests/cdp-robustness.test.ts
+++ b/tests/cdp-robustness.test.ts
@@ -426,7 +426,6 @@ describe('launch() kills orphan Chrome on CDP failure (#136)', () => {
     const { BrowserManager } = await importWithMocks({
       fetchBehavior: (): Promise<Response> =>
         Promise.resolve(new Response('{}', { status: 200 })),
-      connectBehavior: 'success',
       spawnPid: 33333,
       profilePids: [22222],
     });

--- a/tests/model-picker.test.ts
+++ b/tests/model-picker.test.ts
@@ -109,4 +109,45 @@ describe('ChatGPTDriver.selectModel()', () => {
 
     expect(options[2]?.clicked).toBe(true);
   });
+
+  it('opens the current composer pill model picker when the legacy data-testid is absent', async () => {
+    const options: FakeModelOption[] = [
+      { text: 'Instant', clicked: false },
+      { text: 'Thinking', clicked: false },
+      { text: 'Pro • Extended', clicked: false },
+    ];
+    const clickedSelectors: string[] = [];
+
+    const page = {
+      locator: vi.fn((selector: string) => {
+        if (selector === SELECTORS.PROMPT_INPUT) {
+          return new FakeClickableLocator();
+        }
+        if (selector === SELECTORS.MODEL_SELECTOR_BUTTON) {
+          return {
+            click: () => {
+              clickedSelectors.push(selector);
+              return Promise.resolve();
+            },
+          };
+        }
+        if (selector === SELECTORS.MODEL_MENU) {
+          return new FakeModelMenuLocator(options);
+        }
+        throw new Error(`Unexpected selector: ${selector}`);
+      }),
+      keyboard: {
+        press: vi.fn().mockResolvedValue(undefined),
+      },
+    } as const;
+
+    const driver = new ChatGPTDriver(page as unknown as Page);
+    vi.spyOn(driver, 'waitForReady').mockResolvedValue(undefined);
+
+    await driver.selectModel('Pro', true);
+
+    expect(clickedSelectors).toEqual([SELECTORS.MODEL_SELECTOR_BUTTON]);
+    expect(SELECTORS.MODEL_SELECTOR_BUTTON).toContain('__composer-pill');
+    expect(options[2]?.clicked).toBe(true);
+  });
 });

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -11,6 +11,7 @@ import {
   determineBroken,
   formatReportText,
   validateAllSelectors,
+  waitForReportReady,
 } from '../src/core/report.js';
 
 // ── categorizeSelector ────────────────────────────────────
@@ -83,6 +84,27 @@ describe('validateAllSelectors', () => {
     expect(deepResearchReportRoot).toEqual(expect.objectContaining({
       count: 0,
     }));
+  });
+});
+
+describe('waitForReportReady', () => {
+  it('waits for the prompt composer before report selector validation', async () => {
+    const calls: string[] = [];
+    const page = {
+      locator: (selector: string) => {
+        calls.push(selector);
+        return {
+          waitFor: ({ state, timeout }: { state: string; timeout: number }) => {
+            calls.push(`${state}:${String(timeout)}`);
+            return Promise.resolve();
+          },
+        };
+      },
+    };
+
+    await waitForReportReady(page as unknown as Parameters<typeof waitForReportReady>[0], true, 1234);
+
+    expect(calls).toEqual(['#prompt-textarea', 'visible:1234']);
   });
 });
 
@@ -200,6 +222,19 @@ describe('determineBroken', () => {
     const broken = determineBroken(selectors, baseline);
     expect(broken).toHaveLength(1);
     expect(broken[0].name).toBe('COPY_BUTTON');
+  });
+
+  it('does not mark Deep Research contextual selectors as broken on non-Deep-Research reports', () => {
+    const selectors: SelectorResult[] = [
+      { name: 'DEEP_RESEARCH_REPORT_ROOT', selector: 'main', count: 0, category: 'contextual' },
+    ];
+    const baseline: BaselineComparison = {
+      newMisses: ['DEEP_RESEARCH_REPORT_ROOT'],
+      newHits: [],
+      unchanged: 0,
+    };
+    const broken = determineBroken(selectors, baseline);
+    expect(broken).toHaveLength(0);
   });
 
   it('does not mark contextual selectors as broken without baseline', () => {

--- a/tests/response-handler.test.ts
+++ b/tests/response-handler.test.ts
@@ -307,7 +307,7 @@ describe('waitForResponse()', () => {
     }
   });
 
-  it('times out when activity stalls while the stop button remains visible', async () => {
+  it('does not stall while the stop button remains visible during long Pro thinking', async () => {
     const { waitForResponse } = await import('../src/core/driver/response-handler.js');
     const now = vi.spyOn(Date, 'now');
     let tick = 0;
@@ -322,14 +322,20 @@ describe('waitForResponse()', () => {
         { text: 'Thinking...', count: 1, stopVisible: true, copyVisible: false },
         { text: 'Thinking...', count: 1, stopVisible: true, copyVisible: false },
         { text: 'Thinking...', count: 1, stopVisible: true, copyVisible: false },
+        { text: 'Final answer', count: 1, stopVisible: false, copyVisible: true },
       ]) as unknown as Parameters<typeof waitForResponse>[0];
 
-      await expect(waitForResponse(page, {
-        timeout: 30_000,
+      const result = await waitForResponse(page, {
+        timeout: 60_000,
         stallTimeoutMs: 5_000,
         initialMsgCount: 0,
         quiet: true,
-      })).rejects.toThrow('Response stalled');
+      });
+
+      expect(result).toEqual({
+        text: 'Final answer',
+        completed: true,
+      });
     } finally {
       now.mockRestore();
     }


### PR DESCRIPTION
## Summary
- restore model/composer selector coverage for the current ChatGPT DOM while retaining legacy selectors
- recover from unusable CDP endpoints by stopping the saved/profile Chrome process before relaunching
- avoid false `Response stalled` failures while Pro is still actively thinking with the stop button visible
- make `report` wait for composer hydration and avoid Deep Research selector false positives on normal chat pages

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm run deadcode`
- `npm run build`
- `npm test`
- live `node dist/index.mjs status` showed Fail 0
- live `node dist/index.mjs report --format json` returned `broken: []`
- live `node dist/index.mjs ask --sync --model Pro --file /tmp/cavendish-repo-14b2c79.tar.gz ...` completed and returned a repository analysis response

Closes #237


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added readiness wait to ensure the interface is ready before running report checks.

* **Bug Fixes**
  * Broadened UI element detection to improve reliability across layouts.
  * Improved browser/process cleanup and recovery during connection failures.
  * Prevented false "stall" timeouts while active stop controls are visible.

* **Tests**
  * Added and expanded tests covering reconnect cleanup, selector resilience, readiness waiting, and stall behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->